### PR TITLE
feat: add workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # 🎯 Agent Skills
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-5-blue.svg)](./#available-skills)
+[![Skills](https://img.shields.io/badge/skills-6-blue.svg)](./#available-skills)
 [![Release](https://img.shields.io/github/v/release/bntvllnt/agent-skills?display_name=tag&sort=semver)](https://github.com/bntvllnt/agent-skills/releases/latest)
 
 **Compatible with:** Claude Code • OpenCode • Windsurf • Cursor • More via [skills.sh](https://skills.sh)
@@ -86,6 +86,14 @@ Build and operate Convex backends with best practices, validation, and Convex MC
 
 ---
 
+### [Workflow](./workflow/) - High-Velocity Solo Development
+
+Idea to production same-day. Spec-first, quality-gated, pattern-driven development workflow with 7 commands: plan, spike, ship, review, done, drop, workflow.
+
+[View skill documentation →](./workflow/SKILL.md)
+
+---
+
 ## Installation Options
 
 Install specific skill:
@@ -100,6 +108,8 @@ npx skills add bntvllnt/agent-skills --skill git
 npx skills add bntvllnt/agent-skills --skill github
 
 npx skills add bntvllnt/agent-skills --skill convex
+
+npx skills add bntvllnt/agent-skills --skill workflow
 ```
 
 Global install:
@@ -113,6 +123,8 @@ npx skills add bntvllnt/agent-skills --skill git -g
 npx skills add bntvllnt/agent-skills --skill github -g
 
 npx skills add bntvllnt/agent-skills --skill convex -g
+
+npx skills add bntvllnt/agent-skills --skill workflow -g
 ```
 
 Specific agent:
@@ -126,6 +138,8 @@ npx skills add bntvllnt/agent-skills --skill git --agent claude-code
 npx skills add bntvllnt/agent-skills --skill github --agent claude-code
 
 npx skills add bntvllnt/agent-skills --skill convex --agent claude-code
+
+npx skills add bntvllnt/agent-skills --skill workflow --agent claude-code
 ```
 
 ---

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -1,0 +1,385 @@
+# Workflow - High-Velocity Solo Development
+
+Idea to production same-day. Spec-first, quality-gated, pattern-driven.
+
+## Install
+
+```bash
+npx skills add bntvllnt/agent-skills --skill workflow
+```
+
+Global:
+```bash
+npx skills add bntvllnt/agent-skills --skill workflow -g
+```
+
+## Commands
+
+| Command | What |
+|---------|------|
+| `plan {idea}` | Create spec with user journey, ACs, scope |
+| `spike {question}` | Time-boxed exploration, produces go/no-go |
+| `ship` or `ship {idea}` | Implement with build/review/fix loop |
+| `review` | Multi-perspective code review (5-9 perspectives) |
+| `done` | Validate, retro, archive, propose memory update |
+| `drop` | Abandon with learnings preserved |
+| `workflow` | Show current state, suggest next action |
+
+No flags needed — the agent auto-detects intent from your natural language (e.g., "review the spec", "skip tests", "emergency fix", "production ready").
+
+## Quickstart
+
+Here's what a real workflow looks like end-to-end:
+
+```
+You:   plan add JWT authentication
+
+Agent: Parsing idea...
+       Tier: mini (estimated ~80 LOC)
+
+       Writing user journey...
+         ACTOR: Authenticated user
+         GOAL: Log in with email/password, receive JWT
+         1. User submits credentials → System validates → User receives token
+         2. User sends request with token → System verifies → User gets response
+         E1. Invalid credentials → System returns 401 → User sees error message
+
+       Writing acceptance criteria...
+         AC-1: GIVEN valid credentials WHEN POST /auth/login THEN returns JWT token
+         AC-2: GIVEN valid JWT WHEN GET /api/protected THEN returns 200
+         AC-E1: GIVEN invalid credentials WHEN POST /auth/login THEN returns 401
+
+       Mapping scope to ACs...
+         1. Create auth middleware → AC-2
+         2. Create login endpoint → AC-1, AC-E1
+         3. Add tests → AC-1, AC-2, AC-E1
+
+       Running dev-readiness check...
+         User journey:       PASS
+         Acceptance criteria: PASS
+         Scope ↔ AC:         PASS (3 scope → 3 ACs, 0 orphans)
+         Quality checklist:   PASS
+
+       Dev-ready: READY
+       Spec: specs/active/2025-01-29-jwt-auth.md
+
+       Next: Run `ship` to implement.
+
+You:   ship
+
+Agent: Loading spec... mode: LOOP (3 scope items, max 5 iterations)
+
+       Iteration 1: Implementing scope item 1 (auth middleware → AC-2)
+         ✓ Created src/middleware/auth.ts
+         Quick pass: lint ✓ typecheck ✓
+         Scope item 1 [x]
+
+       Iteration 2: Implementing scope item 2 (login endpoint → AC-1, AC-E1)
+         ✓ Created src/routes/auth.ts
+         Quick pass: lint ✓ typecheck ✓
+         Scope item 2 [x]
+         Running dev review (5 perspectives)...
+           Correctness: PASS
+           Security: WARN — add rate limiting to login (medium)
+           Reliability: PASS
+           Performance: PASS
+           DX: PASS
+
+       Iteration 3: Implementing scope item 3 (tests → AC-1, AC-2, AC-E1)
+         ✓ Created src/__tests__/auth.test.ts
+         Quick pass: lint ✓ typecheck ✓
+         Scope item 3 [x]
+
+       Running full pass...
+         Lint: ✓  Typecheck: ✓  Build: ✓  Tests: 3/3 passing ✓
+
+       Exit check:
+         Must Have ACs: 2/2 ✓  Error ACs: 1/1 ✓  Scope: 3/3 ✓
+         Gates: green  Blockers: 0
+
+       CLEAN — Ready. Run `done`.
+
+You:   done
+
+Agent: Validating...
+         All Must Have ACs [x] ✓
+         All Error ACs [x] ✓
+         New tests for new behavior ✓ (3 tests added)
+         Existing tests passing ✓
+         No lint/typecheck errors ✓
+         No hardcoded secrets ✓
+
+       Retro:
+         Estimate: 2h → Actual: 1.5h (75%)
+         Worked: Clean scope-to-AC mapping, no orphan work
+         Didn't: Missed rate limiting — caught in review
+         Next time: Add security checklist for auth features
+
+       Proposing memory update...
+         "Auth features should include rate limiting in quality checklist"
+         → Update project agent config? [yes/no]
+
+       Archived: specs/shipped/2025-01-29-jwt-auth.md
+
+       Human actions: commit → push → deploy → verify
+```
+
+## User Journey: Spec to Production
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        SPEC TO PRODUCTION                          │
+│                                                                     │
+│  YOU                           AGENT                     OUTPUT     │
+│  ───                           ─────                     ──────     │
+│                                                                     │
+│  "plan add rate limiting"                                           │
+│       │                                                             │
+│       ├──────────────────▶  Parse idea                              │
+│                             Select tier: mini                       │
+│                             Write user journey:                     │
+│                               ACTOR: API consumer                   │
+│                               GOAL: Protected from abuse            │
+│                               1. Client sends request               │
+│                               2. System checks rate                 │
+│                               3. Under limit → process              │
+│                               E1. Over limit → 429 + Retry-After   │
+│                             Write ACs (GIVEN/WHEN/THEN)             │
+│                             Map scope ↔ ACs                         │
+│                             Quality checklist                       │
+│                             Dev-readiness: READY ──────▶ spec file  │
+│                                                                     │
+│  "ship"                                                             │
+│       │                                                             │
+│       ├──────────────────▶  Load spec, create tasks                 │
+│                             Iteration 1: middleware ──▶ lint ✓      │
+│                             Iteration 2: config ──────▶ lint ✓      │
+│                                Dev review (5 perspectives)          │
+│                             Iteration 3: tests ───────▶ lint ✓      │
+│                             Full pass: lint ✓ types ✓               │
+│                                         build ✓ test ✓              │
+│                             Exit: all ACs ✓ ──────────▶ CLEAN      │
+│                                                                     │
+│  "also add per-user limits"   (MID-LOOP CHANGE)                    │
+│       │                                                             │
+│       ├──────────────────▶  PAUSE implementation                    │
+│                             Update spec:                            │
+│                               + scope item 4: per-user config      │
+│                               + AC-4: GIVEN user config WHEN...     │
+│                               + journey step 4                      │
+│                             Re-check traceability                   │
+│                             Update tasks                            │
+│                             RESUME loop ───────────────▶ continues  │
+│                                                                     │
+│  "done"                                                             │
+│       │                                                             │
+│       ├──────────────────▶  Validate all ACs ✓                     │
+│                             New tests exist ✓                       │
+│                             No lint/type errors ✓                   │
+│                             Retro captured                          │
+│                             Memory update proposed                  │
+│                             Spec archived ─────────────▶ shipped/   │
+│                                                                     │
+│  YOU (manual)                                                       │
+│       │                                                             │
+│       ├─ git commit + push                                          │
+│       ├─ deploy                                                     │
+│       └─ verify in production                                       │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Key: The spec is updated at every stage. Mid-loop changes are captured in the spec BEFORE implementation. The spec is always the source of truth.
+
+## Reading Order
+
+```
+Start here
+    │
+    ▼
+┌──────────┐     Already know           ┌──────────────────────┐
+│ README   │──── the basics? ──────────▶│ SKILL.md             │
+│ (you are │                            │ (agent instructions)  │
+│  here)   │                            └──────────────────────┘
+└────┬─────┘
+     │ Want to understand a phase?
+     │
+     ├── Plan:    references/actions/plan.md
+     ├── Spike:   references/actions/spike.md
+     ├── Ship:    references/actions/ship.md
+     ├── Review:  references/actions/review.md
+     ├── Done:    references/actions/done.md
+     ├── Drop:    references/actions/drop.md
+     └── Memory:  references/memory-update.md
+
+     │ Need a pattern?
+     │
+     ├── Building: references/patterns/implementation.md
+     ├── Planning: references/patterns/planning.md
+     ├── Debugging: references/patterns/debugging.md
+     ├── Deciding: references/patterns/decisions.md
+     └── Decomposing: references/patterns/decomposition.md
+
+     │ Want to customize output?
+     │
+     ├── Plan:    references/templates/plan-output.md
+     ├── Spike:   references/templates/spike-output.md
+     ├── Ship:    references/templates/ship-output.md
+     ├── Review:  references/templates/review-output.md
+     ├── Done:    references/templates/done-output.md
+     ├── Drop:    references/templates/drop-output.md
+     └── Status:  references/templates/status-output.md
+```
+
+**You don't need to read everything.** SKILL.md is the only file the agent loads. References are loaded on-demand when a phase triggers.
+
+## How It Works
+
+```
+ YOU                          WORKFLOW                         OUTPUT
+──────                        ────────                         ──────
+
+ "plan {idea}"
+      │
+      ├───────────────────▶  Parse idea
+                             User journey (MANDATORY)
+                             Acceptance criteria (MANDATORY)
+                             Scope ↔ AC mapping
+                             Quality checklist
+                             Plan review
+                             Dev-readiness check ──────────▶  specs/active/{slug}.md
+      │
+ "ship"
+      │
+      ├───────────────────▶  Detect mode (ONE-SHOT / LOOP)
+                             Resume state check
+                             ┌─────────────────────┐
+                             │     SHIP LOOP       │
+                             │ build → review → fix│◄──┐
+                             │ exit check (ACs)    │───┘ not clean
+                             │ stuck detection     │
+                             └────────┬────────────┘
+                                      │ clean
+                             Quality gates ────────────────▶  All ACs + scope [x]
+      │
+ "done"
+      │
+      ├───────────────────▶  Validate (ACs + tests + gates)
+                             Capture retro
+                             Propose memory update ────────▶  Agent config learning
+                             Archive spec ─────────────────▶  specs/shipped/{slug}.md
+      │
+ YOU (manual)
+      │
+      ├─ git commit + push
+      ├─ deploy
+      └─ verify in production
+```
+
+### Lifecycle
+
+```
+┌──────────┐  plan   ┌──────────┐ review? ┌───────────┐ ready? ┌───────────┐
+│   IDEA   │────────▶│  DRAFT   │────────▶│ REVIEWING │───────▶│ DEV_READY │
+└──────────┘         └──────────┘         └───────────┘        └─────┬─────┘
+                          ▲                    │                     │ ship
+                          │ revise [?][!]      │                     ▼
+                          └────────────────────┘               ┌───────────┐
+                                                               │IMPLEMENTING│
+┌──────────┐  done   ┌──────────┐  clean  ┌───────────┐       └─────┬─────┘
+│ SHIPPED  │◄────────│  READY   │◄────────│   SHIP    │◄────────────┘
+└──────────┘         └──────────┘         │   LOOP    │──── iterate
+      │                                   └─────┬─────┘
+      │              ┌──────────┐               │ stuck
+      │              │ DROPPED  │◄── drop ──────┘
+      ▼              └──────────┘
+ specs/shipped/                   specs/dropped/
+```
+
+### Quality Gates
+
+```
+ Quick Pass (per edit)                Full Pass (before exit)
+┌──────────────────────┐     ┌─────────────────────────────────────────┐
+│ LINT ──▶ TYPECHECK   │     │ LINT ──▶ TYPECHECK ──▶ BUILD ──▶ TEST  │
+│(changed)  (changed)  │     │(changed)   (full)      (full)  (related)│
+└──────────────────────┘     └─────────────────────────────────────────┘
+```
+
+### Review Notation
+
+```
+[?] unclear    [!] risk    [+] add to scope
+[-] cut scope  [~] rephrase   [ok] approved
+```
+
+## Customization
+
+Edit the skill files directly. Install at user-level or project-level, then modify to match your needs.
+
+```
+workflow/
+├── SKILL.md ──────────────────── Task templates, review systems, risk thresholds
+├── references/
+│   ├── actions/                  ← Action logic (what the agent does)
+│   │   ├── plan.md ───────────── Spec requirements, dev-readiness gates, review rounds
+│   │   ├── ship.md ───────────── Quality gates, iteration limits, exit criteria
+│   │   ├── review.md ─────────── Perspectives (add/remove/change levels)
+│   │   ├── done.md ───────────── Validation checklist, memory update settings
+│   │   └── drop.md ───────────── Drop flow
+│   │
+│   ├── templates/                ← Output templates (what the agent returns to you)
+│   │   ├── plan-output.md ────── Spec summary, codebase impact, analysis, readiness
+│   │   ├── spike-output.md ───── Decision, findings, next step
+│   │   ├── ship-output.md ────── Iteration progress, exit states, spec mutations
+│   │   ├── review-output.md ──── Per-file findings, fix actions, verdict
+│   │   ├── done-output.md ────── Validation results, retro, memory updates
+│   │   ├── drop-output.md ────── Drop reason, learnings, reusable pieces
+│   │   └── status-output.md ──── Current state, progress, suggested next action
+│   │
+│   ├── spec-template.md ─────── Spec structure, generation rules, validation
+│   ├── quality-gates.md ──────── Gate levels (BLOCKING/ADVISORY/SKIP), commands
+│   ├── session-management.md ── Progress tracking, resume, stuck detection
+│   └── memory-update.md ─────── Memory update protocol, agent config targets
+```
+
+**Two layers of customization:**
+
+| Layer | What to edit | Controls |
+|-------|-------------|----------|
+| **Actions** (`actions/*.md`) | Logic, gates, perspectives, limits | What the agent does |
+| **Templates** (`templates/*-output.md`) | Output format, sections, wording | What the agent returns to you |
+
+### Examples
+
+**Change what the agent shows after plan:** Edit `templates/plan-output.md` — add/remove sections, change format.
+
+**Change what review findings look like:** Edit `templates/review-output.md` — change format, add fields, adjust rules.
+
+**Change quality gate commands:** Edit `quality-gates.md` — update auto-detection tables or add explicit commands.
+
+**Add review perspectives:** Edit `actions/review.md` — add rows to the perspectives table.
+
+**Skip typecheck:** Edit `quality-gates.md` — set Typecheck level to SKIP.
+
+**Require manual spec review:** Edit `actions/plan.md` — set manual review gate to BLOCKING.
+
+**Change iteration limits:** Edit `actions/ship.md` — update the "Default Iterations by Size" table.
+
+**Change memory update behavior:** Edit `memory-update.md` — adjust categories, agent targets, or disable proposals.
+
+---
+
+## Key Principles
+
+- **Spec = source of truth**: Always updated, always reflects reality
+- **ACs define done**: Work finishes when all Must Have + Error ACs pass
+- **New code = new tests**: Every new behavior must have tests (BLOCKING)
+- **Two review systems**: Plan review (specs) + dev review (code)
+- **Quality gates**: Auto-detected, skippable — edit skill files to configure
+- **Ship loop**: Build → review → fix with stuck detection + escalation
+- **Risk-aware**: Agent flags HIGH risk changes for human review
+- **Context-aware memory updates**: Done phase reads existing rules, proposes thinking patterns + coding rules + project rules
+- **Human controls deployment**: Agent codes and validates, you push and deploy
+- **16 patterns**: Implementation, planning, debugging, decisions, decomposition
+- **Agent-portable**: Capability fallbacks for agents without task tracking or shell access

--- a/workflow/SKILL.md
+++ b/workflow/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: workflow
+description: High-velocity solo development workflow. Idea to production same-day. 6 actions: plan, spike, ship, review, done, drop.
+---
+
+# Workflow
+
+High-velocity solo development. Idea to production same-day.
+
+## Agent Capabilities
+
+| Capability | Used For | Required | Fallback |
+|------------|----------|----------|----------|
+| File read/write | Specs, config, history | Yes | — |
+| Code search (grep/glob) | Discovery, context | Yes | — |
+| Shell/command execution | Quality gates (lint, build, test) | Yes | List commands for user to run |
+| Task/todo tracking | Phase management | Recommended | Track in spec Progress section |
+| User interaction | Stuck escalation, risk flags | Recommended | Log decisions in spec Notes |
+| Web/doc search | Pattern lookup | No | Use embedded patterns |
+
+**Fallback rule:** If your agent lacks a capability, use the fallback. Never skip the workflow step — adapt the method.
+
+## Commands
+
+| Command | Action | Reference |
+|---------|--------|-----------|
+| `plan {idea}` | Create spec | [plan.md](references/actions/plan.md) |
+| `spike {question}` | Time-boxed exploration | [spike.md](references/actions/spike.md) |
+| `ship` / `ship {idea}` | Implement + validate | [ship.md](references/actions/ship.md) |
+| `review` | Multi-perspective code review | [review.md](references/actions/review.md) |
+| `done` | Validate + retro + archive | [done.md](references/actions/done.md) |
+| `drop` | Abandon, preserve learnings | [drop.md](references/actions/drop.md) |
+| `workflow` | Show state + suggest next | [Status](#status-action) (below) |
+
+No flags needed. The agent auto-detects intent from context:
+- "review the spec" → manual review pause
+- "skip tests" → skip test gate (documented)
+- "emergency fix" → bypass spec ceremony
+- "production ready" → production validation
+
+## Flow
+
+```
+plan {idea} → ship → [implement/review/fix loop] → done
+```
+
+Quick mode (<2h): `ship {idea} → done`
+
+## Philosophy
+
+- **Spec-first**: All work needs a spec (creates one if missing)
+- **Ship loop**: Build → review → fix until clean
+- **Quality gates**: lint → typecheck → build → test (auto-detected per project)
+- **Human controls deployment**: Agent codes, you push/deploy
+- **Done same-day**: Scope to what ships today
+
+## Spec Tiers
+
+| Tier | Size | Spec | Task Tracking |
+|------|------|------|---------------|
+| trivial | <5 LOC | None — just do it | No |
+| micro | <30 LOC | Inline comment in code | No |
+| mini | <100 LOC | Spec file, minimal | Yes (if available) |
+| standard | 100+ LOC | Full spec with checklist | Yes (if available) |
+
+## Action Router
+
+```
+User input
+  │
+  ├─ "plan", "spec", "design"           → Load references/actions/plan.md
+  ├─ "spike", "explore", "investigate"   → Load references/actions/spike.md
+  ├─ "ship", "implement", "fix", "build" → Load references/actions/ship.md
+  ├─ "review", "check code"              → Load references/actions/review.md
+  ├─ "done", "finish", "complete"        → Load references/actions/done.md
+  ├─ "drop", "abandon"                   → Load references/actions/drop.md
+  └─ "workflow", "what's next", "status" → Status Action (below)
+```
+
+**Loading rule:** Read the action file BEFORE executing. The action file contains all logic, task templates, and references needed.
+
+## Status Action
+
+No separate action file — logic is inline here. Detect current state, suggest next action:
+
+```
+1. Check specs/active/ for active spec
+2. Check git status for uncommitted work
+3. Check task list for in-progress items
+
+State → Suggestion:
+  No spec, no changes    → "Ready. Run: plan {idea}"
+  Active spec, no code   → "Spec ready. Run: ship"
+  Active spec, code WIP  → "In progress. Run: ship (resumes)"
+  Active spec, code done → "Ready to close. Run: done"
+  No spec, dirty tree    → "Uncommitted work. Run: ship (creates spec) or done"
+```
+
+Output: Follow [status-output.md](references/templates/status-output.md).
+
+## Project Structure
+
+```
+specs/
+  active/       ← Current work (0-1 specs)
+  shipped/      ← Completed features
+  dropped/      ← Abandoned with learnings
+  history.log   ← One-line per feature shipped/dropped
+```
+
+## Configuration
+
+All behavior is configurable by editing the skill files directly.
+
+| What to change | Edit |
+|----------------|------|
+| Action logic, gates, limits | `references/actions/{action}.md` |
+| Output format | `references/templates/{action}-output.md` |
+| Spec structure | `references/spec-template.md` |
+| Quality gate commands/levels | `references/quality-gates.md` |
+| Session resume, stuck detection | `references/session-management.md` |
+
+## References
+
+Actions:
+- [Plan](references/actions/plan.md) | [Ship](references/actions/ship.md) | [Review](references/actions/review.md) | [Done](references/actions/done.md) | [Drop](references/actions/drop.md) | [Spike](references/actions/spike.md)
+
+Output templates:
+- [Plan](references/templates/plan-output.md) | [Ship](references/templates/ship-output.md) | [Review](references/templates/review-output.md) | [Done](references/templates/done-output.md) | [Drop](references/templates/drop-output.md) | [Spike](references/templates/spike-output.md) | [Status](references/templates/status-output.md)
+
+Specs & gates:
+- [Spec template](references/spec-template.md) | [Quality gates](references/quality-gates.md) | [Session management](references/session-management.md) | [Memory update](references/memory-update.md)
+
+Patterns:
+- [Implementation](references/patterns/implementation.md) | [Planning](references/patterns/planning.md) | [Debugging](references/patterns/debugging.md) | [Decisions](references/patterns/decisions.md) | [Decomposition](references/patterns/decomposition.md)

--- a/workflow/references/actions/done.md
+++ b/workflow/references/actions/done.md
@@ -1,0 +1,121 @@
+# Done Action
+
+> **Agent:** Load this file when `done` triggers. Read the user's agent config (global + project rules) before proposing memory updates.
+
+Validate, archive spec, capture learnings. Does NOT deploy — that's human-controlled.
+
+---
+
+## Step 1: Pre-Ship Validation
+
+### Quality Gate
+
+| Check | Required |
+|-------|----------|
+| All Must Have ACs passing [x] | Yes (MANDATORY) |
+| All Error Criteria ACs passing [x] | Yes (MANDATORY) |
+| All scope items checked [x] | Yes |
+| Ship exit was CLEAN (not partial/stuck/hard-stop) | Yes |
+| New tests for new behavior | Yes (BLOCKING) |
+| Existing tests passing | Yes |
+| No typecheck/lint errors | Yes |
+| No debug statements (console.log, debugger, print, pdb, etc.) | Yes |
+| No hardcoded secrets | Yes |
+| Can rollback (git revert works, no irreversible migrations) | Yes |
+| No unresolved bugs (all fixed or deferred) | Yes |
+
+**New test mandate:** Every new behavior MUST have at least one test. Not just "existing tests pass" — new code needs new tests. If test infrastructure doesn't exist, propose setting it up. If user declines, document the skip reason.
+
+ACs are the definition of DONE. Scope items track implementation tasks, but ACs determine if the feature actually works as specified in the user journey.
+
+If any check fails: STOP. Show what's remaining. Suggest `ship` to continue.
+
+**Unresolved bugs are blocking.** All entries in "Encountered Bugs" must be Fixed or Deferred before done.
+
+### Production Validation
+
+Additional checks for production deploys:
+- Schema validation (if schema files changed)
+- Deploy readiness check
+- Security audit
+- Performance validation
+
+## Step 2: Retro (Always Runs)
+
+Analyze the session and capture learnings:
+
+    ### Ship Retro ({DATE})
+    **Estimate vs Actual:** {X}h → {Y}h ({accuracy}%)
+    **What worked:** {insight}
+    **What didn't:** {insight with root cause}
+    **Next time:** {specific improvement}
+
+Write retro to:
+1. Spec file `## Notes` section
+2. Project learnings file (if maintained)
+
+## Step 3: Record Timestamp
+
+Add done entry to spec Timeline:
+
+    | done | {ISO_TIMESTAMP} | {total_duration} | - |
+
+## Step 4: Propose Memory Update
+
+Follow the full protocol in [memory-update.md](../memory-update.md):
+1. Read existing user + project rules (MANDATORY)
+2. Extract learnings (5 categories)
+3. Classify & target (user-level vs project-level)
+4. Present structured proposal for user approval
+
+## Step 5: CI Integration (Optional)
+
+If the agent has access to CI pipelines (GitHub Actions, GitLab CI, etc.):
+
+```
+1. Push to feature branch (if not already pushed)
+2. Wait for CI pipeline to complete
+3. Read CI results:
+   - Build: PASS/FAIL
+   - Tests: PASS/FAIL (N passing, N failing)
+   - Lint/typecheck: PASS/FAIL
+   - Coverage: {percent} (delta from main)
+4. Include CI status in validation output
+5. If CI fails: treat as validation failure — suggest `ship` to fix
+```
+
+CI is ADVISORY by default. Edit this file to make it BLOCKING.
+
+## Step 6: Archive Spec
+
+```
+mkdir -p specs/shipped
+mv specs/active/{spec-file}.md specs/shipped/
+Update spec: status → shipped, shipped → {YYYY-MM-DD}
+```
+
+## Step 7: Log to History
+
+Append to `specs/history.log`:
+```
+{DATE} | shipped | {slug} | {estimate}h→{actual}h | {duration} | {summary}
+```
+
+## Step 8: Output
+
+Follow the output template in `references/templates/done-output.md`.
+
+Covers: validation passed (retro + memory update + next steps) and validation failed.
+
+## Express Ship (No Spec)
+
+If no spec exists (one-shot build):
+1. Skip spec archival
+2. Still run validation
+3. Log to history
+
+## Never
+
+- Never runs `git push`
+- Never runs deploy commands
+- Never makes production changes

--- a/workflow/references/actions/drop.md
+++ b/workflow/references/actions/drop.md
@@ -1,0 +1,55 @@
+# Drop Action
+
+> **Agent:** Load this file when `drop` triggers.
+
+Abandon feature, preserve learnings. Nothing is wasted.
+
+---
+
+## Step 1: Confirm
+
+Ask before dropping:
+- Why dropping? (Categories: too complex, wrong approach, no longer needed, blocked, time constraint)
+- Any reusable pieces? (Code, patterns, research)
+
+## Step 2: Capture Learnings
+
+Write drop retro to spec Notes:
+
+```markdown
+### Drop Retro ({DATE})
+**Reason:** {category} — {details}
+**Time spent:** {hours}
+**Reusable pieces:**
+- {code/pattern/insight that can be reused}
+**What we learned:**
+- {key insight from the attempt}
+**If revisited:**
+- {what to do differently next time}
+```
+
+## Step 3: Record Timestamp
+
+Add drop entry to spec Timeline:
+```markdown
+| dropped | {ISO_TIMESTAMP} | {time_spent} | {reason} |
+```
+
+## Step 4: Archive Spec
+
+```
+mkdir -p specs/dropped
+mv specs/active/{spec-file}.md specs/dropped/
+Update spec: status → dropped, dropped → {YYYY-MM-DD}
+```
+
+## Step 5: Log to History
+
+Append to `specs/history.log`:
+```
+{DATE} | dropped | {slug} | {estimate}h→{actual}h | {reason} | {key_learning}
+```
+
+## Step 6: Output
+
+Follow the output template in `references/templates/drop-output.md`.

--- a/workflow/references/actions/plan.md
+++ b/workflow/references/actions/plan.md
@@ -1,0 +1,239 @@
+# Plan Action
+
+> **Agent:** Load this file when `plan` triggers. Also load `references/spec-template.md` — it defines spec structure and validation rules.
+
+Parse idea, create spec, estimate effort. Output: spec file ready for `ship`.
+
+**The spec template (`references/spec-template.md`) is the SINGLE SOURCE OF TRUTH for spec structure, generation rules, and validation.** This file defines the orchestration — template defines the content.
+
+---
+
+## Task Tracking (MANDATORY for mini/standard)
+
+Before starting planning, create tasks in your agent's built-in task/todo system:
+
+```
+[ ] Parse idea and identify scope
+[ ] Codebase impact analysis (read affected code, map dependencies)
+[ ] Generate spec (following spec-template.md generation order)
+[ ] Run dev-readiness check (spec-template.md validation rules)
+[ ] All dev-readiness gates PASS
+```
+
+Update tasks as you work. One in-progress at a time.
+
+## Step 0: Detect Project
+
+```
+Check project for:
+  - Monorepo (turbo.json)
+  - Package manager (pnpm/yarn/bun/npm from lockfile)
+  - Test runner (vitest/jest/pytest from config)
+  - Framework (next/expo/convex from package.json)
+```
+
+## Step 1: Parse Idea
+
+Extract from user input:
+- **What**: Feature/fix description
+- **Why**: Problem being solved
+- **Who**: User persona affected
+- **Scope signal**: Size estimate (trivial/micro/mini/standard)
+
+## Step 2: Select Thinking Pattern
+
+| Situation | Pattern |
+|-----------|---------|
+| Clear requirements | Chain-of-thought — step by step |
+| Multiple approaches | Tree-of-thought — enumerate, score, choose |
+| After failure | Reflexion — record failure, adjust, retry |
+| Large scope | Decomposition — split into independent parts |
+
+## Step 3: Generate Spec
+
+**Follow `references/spec-template.md` exactly.** The template defines:
+- Generation order (context → codebase → journey → ACs → scope → checklist → risks → state → analysis)
+- Per-section generation rules
+- Traceability requirements
+- Validation rules
+
+Key principle: **Read the codebase BEFORE writing the spec.** Codebase impact analysis is MANDATORY and informs every section that follows.
+
+Create spec file at `specs/active/{YYYY-MM-DD}-{slug}.md`.
+
+### Tier Selection
+
+| Tier | Size | Spec |
+|------|------|------|
+| trivial | <5 LOC | None — just implement |
+| micro | <30 LOC | Inline comment in code |
+| mini | <100 LOC | Mini template (see spec-template.md) |
+| standard | 100+ LOC | Full template (see spec-template.md) |
+
+### Pre-Mortem (Standard Tier)
+
+Assume the feature failed. Why?
+
+```
+For each risk:
+  Impact: HIGH/MEDIUM/LOW
+  Likelihood: HIGH/MEDIUM/LOW
+  Mitigation: What prevents this?
+  Kill criteria: When do we abandon this approach?
+```
+
+For stateful features, include state machine analysis (see spec-template.md).
+
+## Step 4: Spec Review
+
+Before finalizing, self-verify:
+
+| Check | Question |
+|-------|----------|
+| Clarity | Could another developer implement from this spec alone? |
+| Scope | Can this ship today? Anything cuttable? |
+| Testability | Is every scope item verifiable? |
+| Risks | Are kill criteria defined for high risks? |
+| Completeness | Quality checklist covers edge cases? |
+| Codebase | Did I actually read the code? Are affected files mapped? |
+
+If any check fails, revise the spec before outputting.
+
+## Step 5: Manual Review Gate
+
+**BLOCKING for standard tier.** Pause for human approval before dev-readiness check.
+
+When user requests review ("review the spec", "let me check") or tier is standard, pause for human review before dev.
+
+### Review Notation
+
+Reviewers annotate the spec with inline markers:
+
+| Marker | Meaning |
+|--------|---------|
+| `[?]` | Unclear — needs clarification |
+| `[!]` | Risk — not addressed or underestimated |
+| `[+]` | Missing — should be added to scope |
+| `[-]` | Cut — remove from scope (over-engineered) |
+| `[~]` | Rephrase — intent is right, wording is wrong |
+| `[ok]` | Approved — explicitly signed off |
+
+### Review Flow
+
+```
+Spec created
+     │
+     ▼
+Present spec for review
+     │
+     ├─ All [ok], no [?]/[!] ──▶ READY
+     │
+     ├─ Has [?] or [~] ────────▶ NEEDS_WORK → revise, re-present
+     │
+     ├─ Has [!] ───────────────▶ NOT_READY → address risks, re-review
+     │
+     └─ Has [+] or [-] ────────▶ CONDITIONAL → apply scope changes, re-score
+```
+
+Max 3 rounds. After round 3: must reach READY or user says "proceed anyway".
+
+## Step 6: Dev-Readiness Check
+
+**BLOCKING gate before `ship` can start.**
+
+Run the validation rules from `references/spec-template.md` (Validation Rules table). All 13 rules must pass.
+
+### Readiness Algorithm
+
+```
+ready_to_dev(spec):
+  Run all validation rules from spec-template.md
+
+  mandatory_fails = rules 1-8 that fail
+  standard_fails = rules 9-13 that fail
+
+  IF len(all_fails) == 0:
+    RETURN READY
+  ELIF mandatory_fails:
+    RETURN NOT_READY (cannot proceed)
+  ELIF only standard_fails:
+    RETURN CONDITIONAL (can proceed with acknowledgment)
+```
+
+Additional checks (beyond template validation):
+
+```
+  # Estimate within same-day
+  IF estimate > 8h:
+    WARN "Exceeds same-day. Split or cut scope."
+
+  # Risks addressed (standard tier)
+  IF tier == standard AND unmitigated HIGH risks:
+    BLOCK "Unmitigated HIGH risks: {list}"
+
+  # Dependencies resolved
+  IF external blockers (APIs, access, data):
+    BLOCK "Unresolved dependencies: {list}"
+
+  # Manual review (if requested)
+  IF review_required AND verdict != READY:
+    BLOCK "Spec review not approved"
+```
+
+## Step 7: Output
+
+**Follow the output template in `references/templates/plan-output.md`.**
+
+Always return: file path, status, codebase impact, analysis (improvements + gaps + questions + risks), readiness scorecard.
+
+### Dev-Readiness State Diagram
+
+```
+                   plan {idea}
+                       │
+                       ▼
+                 ┌───────────┐
+                 │   DRAFT   │
+                 │ (spec     │
+                 │  created) │
+                 └─────┬─────┘
+                       │
+          ┌────────────┼────────────┐
+          │            │            │
+     (user asks    (auto-check)  (trivial/micro)
+      for review)      │            │
+          │            │            │
+          ▼            ▼            ▼
+   ┌────────────┐ ┌─────────┐  ┌───────┐
+   │  REVIEWING │ │ CHECKING│  │ READY │──▶ ship
+   │  (human)   │ │ (auto)  │  │ (skip)│
+   └──────┬─────┘ └────┬────┘  └───────┘
+          │             │
+     [?][!][-][+]  blockers?
+          │             │
+     ┌────┴────┐   ┌───┴────┐
+     │ Revise  │   │  FIX   │
+     │ (max 3) │   │blockers│
+     └────┬────┘   └───┬────┘
+          │             │
+          ▼             ▼
+   ┌────────────┐ ┌─────────┐
+   │  APPROVED  │ │  CLEAR  │
+   │  (verdict: │ │ (0      │
+   │   READY)   │ │ blockers│
+   └──────┬─────┘ └────┬────┘
+          │             │
+          └──────┬──────┘
+                 ▼
+           ┌───────────┐
+           │ DEV_READY │──▶ ship
+           └───────────┘
+```
+
+## Tier Bypass
+
+- **trivial** (<5 LOC): Skip spec creation entirely. Just implement.
+- **micro** (<30 LOC): Inline spec as code comment. No file.
+- **mini** (<100 LOC): Mini template from spec-template.md.
+- **standard** (100+ LOC): Full template from spec-template.md.
+- **Emergency**: User says "emergency fix" or "hotfix" → skip spec, log reason in history.

--- a/workflow/references/actions/review.md
+++ b/workflow/references/actions/review.md
@@ -1,0 +1,74 @@
+# Review Action
+
+> **Agent:** Load this file when `review` triggers or during ship loop review cycles.
+
+Multi-perspective code review. Runs during ship loop or standalone.
+
+---
+
+## Modes
+
+| Mode | Perspectives | When |
+|------|-------------|------|
+| Quick | Core 5 only | Small changes, single file |
+| Standard | Core 5 + triggered conditionals | Default |
+| Deep | All 9 | Large features, pre-production |
+
+## Perspectives
+
+### Core (Always)
+
+| # | Perspective | Key Question |
+|---|------------|--------------|
+| 1 | Correctness | Does it do the right thing? Edge cases? Regressions? |
+| 2 | Security | Input validated? Auth correct? Secrets safe? No injection? |
+| 3 | Reliability | Error paths handled? Graceful degradation? Timeouts? Cleanup? |
+| 4 | Performance | N+1 queries? Unnecessary computation? Bundle impact? Hot path? |
+| 5 | DX | Readable? Good names? Actionable errors? Types guide usage? |
+
+### Conditional (Add When Triggered)
+
+| # | Perspective | Trigger | Key Question |
+|---|------------|---------|--------------|
+| 6 | Scalability | Shared state, DB, multi-instance | Thread safe? Works at 10x? Horizontally scalable? |
+| 7 | Observability | Production service, background job | Structured logging? Metrics? Traceable? Health signals? |
+| 8 | Testability | Complex branching, critical logic | Tests exist? Assert behavior not implementation? Coverage gaps? |
+| 9 | Accessibility | UI components | Semantic HTML? Keyboard nav? Screen reader? Contrast? |
+
+## Execution
+
+For each active perspective:
+
+```
+1. Read all changed files
+2. Evaluate against perspective checklist
+3. Classify findings:
+   - PASS: Meets criteria
+   - WARN: Concern, not blocking (severity: low/medium/high)
+   - FAIL: Must fix before shipping (BLOCKING)
+4. Output structured findings
+```
+
+Run perspectives in parallel when possible.
+
+## Output
+
+Follow the output template in `references/templates/review-output.md`.
+
+Key format: `{file}:{line} — FAIL/WARN [{perspective}] {description}` + `Fix: {action}`. Flat list, actionable only, no PASS noise.
+
+## Iteration Limit
+
+Max 3 review iterations per ship cycle. If still blocking after 3:
+- Present remaining issues to user
+- User decides: fix, defer, or accept risk
+
+## When Review Triggers (During Ship Loop)
+
+| Condition | Review? |
+|-----------|---------|
+| Every 2-3 implementation iterations | Yes (quick) |
+| Before exit check | Yes (standard) |
+| User requests `review` | Yes (user-chosen mode) |
+| Security-sensitive code changed | Yes (standard, security focus) |
+| Public API changed | Yes (standard) |

--- a/workflow/references/actions/ship.md
+++ b/workflow/references/actions/ship.md
@@ -1,0 +1,350 @@
+# Ship Action
+
+> **Agent:** Load this file when `ship` triggers. Also load `references/quality-gates.md` for gate commands and `references/session-management.md` for resume/stuck detection.
+
+Implement features with a build/review/fix loop. Handles both quick one-shot and iterative spec-driven work.
+
+---
+
+## Mode Detection
+
+```
+Active spec in specs/active/?
+  YES → LOOP mode (iterate until spec complete)
+  NO  → ONE-SHOT mode (create inline spec, implement, validate)
+```
+
+## Task Tracking (MANDATORY for mini/standard)
+
+Before starting any implementation, create tasks in your agent's built-in task/todo system. Track what to build AND what to validate.
+
+**Create these tasks at the start of each ship cycle:**
+```
+[ ] {scope item 1} → AC-{N}
+[ ] {scope item 2} → AC-{N}
+[ ] ...
+[ ] Quick pass: lint + typecheck (changed files)
+[ ] Review: run perspectives
+[ ] Fix BLOCKING issues
+[ ] Full pass: lint (changed) + typecheck (full) + build (full) + test (related)
+[ ] Exit check: all Must Have ACs + Error ACs + scope items passing
+```
+
+Update tasks as you work: mark in-progress when starting, complete when done. One task in-progress at a time.
+
+## Phase 0: Setup
+
+1. **Detect project stack** (monorepo, framework, test runner, linter)
+2. **Load active spec** (if LOOP mode) or create inline spec (ONE-SHOT)
+3. **Detect resume state** (see session-management.md):
+   - FRESH: No prior work — start from beginning
+   - RESUMING: Prior progress found — resume from last checkpoint
+   - STUCK: Multiple failed iterations — escalate
+   - READY_FOR_DONE: All scope complete — suggest `done`
+
+## Spec-First Enforcement
+
+```
+Has spec?
+  YES → Continue
+  NO  → Estimate size
+    trivial (<5 LOC)  → Implement directly, no spec
+    micro (<30 LOC)   → Create inline comment spec
+    mini (<100 LOC)   → Create spec file (minimal)
+    standard (100+)   → Create full spec (suggest `plan` first)
+    emergency/hotfix   → Skip spec, log reason
+```
+
+## Bug Mode Detection
+
+When fixing bugs, classify:
+
+| Type | Signal | Approach |
+|------|--------|----------|
+| Simple | Clear cause, single file | Direct fix + regression test |
+| Complex | Unclear cause, multiple files, intermittent | Scientific debugging (see patterns/debugging.md) |
+
+Complex bugs require:
+1. Symptom capture (exact error, reproduction steps)
+2. Hypothesis formation (ranked by likelihood)
+3. Evidence collection (binary search, instrumentation)
+4. Root cause confirmation
+5. Fix + regression test
+
+**Bug fix ACs (auto-generate if not in spec):**
+- AC-B1: GIVEN {reproduction steps} WHEN {trigger} THEN bug no longer occurs
+- AC-B2: GIVEN fix applied WHEN regression test runs THEN test passes
+- AC-B3: GIVEN fix applied WHEN existing tests run THEN no regressions
+
+## ONE-SHOT Flow
+
+For quick fixes and small features without an active spec:
+
+```
+1. Analyze scope (files affected, estimated LOC)
+2. Create plan (brief, inline)
+3. Implement
+4. Quality gates (lint → typecheck → build → test)
+5. Self-review (re-read all changes)
+6. Output summary
+```
+
+## LOOP Flow (Ship Loop)
+
+Core iteration algorithm for spec-driven work:
+
+```
+iteration = 0
+max_iterations = spec.max_iterations OR default_by_size()
+stuck_threshold = max(3, max_iterations / 2)
+
+WHILE iteration < max_iterations:
+  iteration++
+
+  # 1. BUILD
+  Pick next unchecked scope item
+  Implement it
+  Run quick quality pass (lint + typecheck on changed files)
+  Mark scope item [x] if passing
+
+  # 2. REVIEW (every 2-3 iterations or on request)
+  Run multi-perspective review (see actions/review.md)
+  Collect issues: BLOCKING vs WARN
+
+  # 3. FIX
+  Fix all BLOCKING issues
+  Log WARN issues in spec notes
+
+  # 4. EXIT CHECK
+  all_must_have_acs = all Must Have ACs checked [x]
+  all_error_acs = all Error Criteria ACs checked [x]
+  all_scope_complete = all spec scope items checked [x]
+  quality_clean = lint + typecheck + build + test all pass
+  no_blockers = no BLOCKING review issues
+
+  IF all_must_have_acs AND all_error_acs AND all_scope_complete
+     AND quality_clean AND no_blockers:
+    EXIT → clean (suggest `done`)
+
+  # ACs are the source of truth for "is work done?"
+  # Scope items track implementation progress.
+  # Both must be complete.
+
+  # 5. STUCK DETECTION
+  progress = scope_items_completed / total_scope_items
+  IF iteration >= stuck_threshold AND progress < 0.5:
+    ESCALATE (see Stuck Escalation below)
+```
+
+### Default Iterations by Size
+
+| Size | Max Iterations | Stuck Threshold |
+|------|---------------|-----------------|
+| mini | 5 | 3 |
+| standard (small) | 8 | 4 |
+| standard (medium) | 12 | 6 |
+| standard (large) | 20 | 10 |
+
+## Quality Gates (Per Iteration)
+
+**Quick pass** (after each edit batch):
+- Lint changed files
+- Typecheck changed files
+
+**Full pass** (before exit):
+- Lint changed files
+- Typecheck full project
+- Build full project
+- Test related tests
+
+Auto-detect tooling from project files. See `references/quality-gates.md`.
+
+## Stuck Escalation
+
+Three levels, triggered by lack of progress:
+
+| Level | Trigger | Action |
+|-------|---------|--------|
+| Warning | At stuck_threshold, progress < 50% | Log warning, continue |
+| Pause | 2 iterations after warning, no progress | Present options to user |
+| Hard stop | At max_iterations | Force exit with summary |
+
+**Pause options:**
+1. Continue with different approach
+2. Reduce scope (cut items)
+3. Defer to next session
+4. Drop feature entirely
+
+## Bug Encounter Protocol
+
+When a bug is found during implementation:
+
+```
+1. Log bug in spec under "## Encountered Bugs"
+   Format: BUG-{N}: {summary} | Status: Investigating/Fixed/Deferred
+2. Classify: blocks current scope item? (Y/N)
+3. If blocking: fix immediately, add regression test
+4. If non-blocking: defer, continue with scope
+5. All bugs must be Fixed or Deferred before `done`
+```
+
+## Review Integration
+
+Review runs automatically during ship loop. Perspectives:
+
+**Core (always):** Correctness, Security, Reliability, Performance, DX
+**Conditional:** Scalability, Observability, Testability, Accessibility
+
+See `actions/review.md` for full perspective details.
+
+## Progress Tracking
+
+Update spec after each iteration:
+
+```markdown
+## Progress
+| Item | Status | Iteration |
+|------|--------|-----------|
+| Scope item 1 | [x] Complete | 2 |
+| Scope item 2 | [~] In progress | 3 |
+| Scope item 3 | [ ] Pending | - |
+```
+
+## Output
+
+Follow the output template in `references/templates/ship-output.md`.
+
+Covers: iteration output, 4 exit states (clean/partial/stuck/hard stop), spec mutation output.
+
+Exit states:
+
+| State | Condition |
+|-------|-----------|
+| Clean | All Must Have + Error ACs pass, all scope done, gates green, no blockers |
+| Partial | Scope done but ACs failing |
+| Stuck | Hit stuck threshold, user chose to stop |
+| Hard stop | Hit max iterations |
+
+## Risk Flag System
+
+After each implementation step, assess risk level of changes:
+
+```
+For each changed file, check:
+  Auth/security logic?        → HIGH
+  DB schema/migration?        → HIGH
+  Payment/billing?            → HIGH
+  Public API contract?        → HIGH
+  Delete/destructive op?      → HIGH
+  Config/environment?         → MEDIUM
+  New dependency?             → MEDIUM
+  Performance-critical path?  → MEDIUM
+  Internal refactor?          → LOW
+  Tests/docs only?            → LOW
+
+  Highest risk across all changes = overall risk
+```
+
+| Risk | Action |
+|------|--------|
+| LOW | Continue autonomously |
+| MEDIUM | Note in spec, mention in self-review |
+| HIGH | **PAUSE.** Present to user: what changed, what could go wrong, recommendation. User approves before continuing. |
+
+Configurable by editing this file directly.
+
+## Production Validation
+
+Concrete checks for production deploys. Run these in addition to standard gates.
+
+```
+Auto-detect and run (if tooling exists):
+
+1. Dependency vulnerability scan
+   npm audit / pnpm audit / yarn audit / pip-audit / cargo audit
+   Level: BLOCKING (critical/high), ADVISORY (moderate/low)
+
+2. Security scan
+   Check for: hardcoded secrets, SQL injection patterns,
+   XSS vectors, open redirects, insecure dependencies
+   Level: BLOCKING
+
+3. Build verification
+   Full production build (not dev build)
+   Command: {framework build command} with production flags
+   Level: BLOCKING
+
+4. Smoke test (if test infrastructure supports it)
+   Start server, hit health endpoint, verify response
+   Level: ADVISORY
+
+5. Bundle/artifact size check
+   Compare to previous build if baseline exists
+   Level: ADVISORY (warn if >20% increase)
+
+6. Schema validation (if schema files changed)
+   Verify migration is reversible
+   Check for breaking changes in API contracts
+   Level: BLOCKING
+```
+
+## Intent Auto-Detection
+
+No flags needed. The agent detects intent from natural language:
+
+| User Says | Agent Does |
+|-----------|-----------|
+| "emergency fix", "hotfix" | Skip spec ceremony |
+| "skip tests", "don't run tests" | Skip test gate (log reason) |
+| "skip review" | Skip review perspectives |
+| "deploy to production", "production ready" | Run production validation |
+| "force it", "proceed anyway" | Proceed past CONDITIONAL readiness |
+
+Always document any skipped gates in output.
+
+## Parallel Execution
+
+When scope items are independent (no shared files), they can be implemented in parallel if your agent supports multi-tool or concurrent execution.
+
+```
+Check: Do scope items share files in Codebase Impact?
+  NO shared files → parallelizable (implement simultaneously)
+  YES shared files → sequential (implement in order)
+
+Parallel rules:
+  - Each parallel item gets its own quick pass
+  - Merge results before running full pass
+  - If parallel items conflict at merge → resolve, re-run quick pass
+  - Review runs once after all parallel items complete
+```
+
+## Spec Mutation Protocol (Mid-Loop Changes)
+
+When user requests scope changes during the ship loop:
+
+```
+User: "also add X" / "change Y to Z" / "remove W"
+  │
+  ├─ 1. PAUSE current implementation
+  ├─ 2. UPDATE SPEC FILE:
+  │     - Add/modify/remove scope items
+  │     - Add/modify acceptance criteria (GIVEN/WHEN/THEN)
+  │     - Update user journey if flow changes
+  │     - Re-run traceability check (scope ↔ AC, no orphans)
+  │     - Update Progress section
+  ├─ 3. UPDATE TASKS: create new, delete obsolete
+  ├─ 4. RE-ASSESS: does change affect tier, iteration limit, or risk?
+  ├─ 5. RESUME ship loop with updated scope
+  │
+  └─ RULE: Never implement untracked work.
+           If it's not in the spec, update the spec first.
+```
+
+The spec is the SINGLE SOURCE OF TRUTH. It must reflect reality at all times.
+
+## Never
+
+- Never runs `git push`
+- Never runs deploy commands
+- Never makes production changes
+- Never runs destructive git commands (`reset --hard`, `clean -f`, `push --force`)

--- a/workflow/references/actions/spike.md
+++ b/workflow/references/actions/spike.md
@@ -1,0 +1,72 @@
+# Spike Action
+
+> **Agent:** Load this file when `spike` triggers.
+
+Time-boxed exploration. Answers a question, produces go/no-go. NOT a shippable feature.
+
+---
+
+## When to Spike
+
+- Unknown technology: "Can we use X for this?"
+- Feasibility: "Is this approach even possible?"
+- Performance: "Will this be fast enough?"
+- Integration: "Does X work with Y?"
+- Architecture: "Which pattern fits best?"
+
+## Flow
+
+```
+spike {question}
+     │
+     ▼
+┌──────────────────────────┐
+│ 1. DEFINE                │
+│    Question: {what}      │
+│    Time box: {hours}     │
+│    Success: {go criteria} │
+│    Kill: {stop criteria}  │
+└────────────┬─────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 2. EXPLORE               │
+│    Research / prototype   │
+│    Track findings         │
+│    Check kill criteria    │
+└────────────┬─────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 3. DECIDE                │
+│    GO / NO-GO / UNCLEAR  │
+│    Evidence summary       │
+│    Next step              │
+└──────────────────────────┘
+```
+
+## Task Template
+
+```
+[ ] Define question and success/kill criteria
+[ ] Set time box (default 1h, max 4h)
+[ ] Explore: research and prototype
+[ ] Document findings
+[ ] Decision: GO / NO-GO / NEEDS_MORE_INFO
+[ ] Clean up: delete prototype code
+[ ] Log to history
+```
+
+## Output
+
+Follow the output template in `references/templates/spike-output.md`.
+
+## Rules
+
+- Spike code is THROWAWAY. Delete before proceeding.
+- Never ship spike code directly. If GO, start fresh with `plan`.
+- Time box is hard. If kill criteria hit, stop immediately.
+- Log spike to `specs/history.log`:
+  ```
+  {DATE} | spike | {slug} | {time}h | {GO/NO-GO} | {key finding}
+  ```

--- a/workflow/references/memory-update.md
+++ b/workflow/references/memory-update.md
@@ -1,0 +1,107 @@
+# Memory Update Protocol
+
+> **Agent:** Load this file during `done` Step 4. Read the user's agent config (global + project rules) before proposing.
+
+After retro, propose updating the agent's persistent memory with learnings from this session.
+
+---
+
+## Step 1: Read Existing Rules (MANDATORY)
+
+**Before proposing anything, understand what already exists.**
+
+Read both levels using the Agent Config Targets table below. Build a mental model:
+- What thinking patterns are already defined?
+- What coding standards exist?
+- What quality gates are configured?
+- What project-specific conventions are enforced?
+- What security/testing rules exist?
+
+**Why:** Proposals that duplicate existing rules waste time. Proposals that contradict existing rules cause confusion. Understanding the hierarchy ensures updates slot in correctly.
+
+## Step 2: Extract Learnings
+
+From the retro and session history, identify learnings in 5 categories:
+
+| Category | What to extract | Example |
+|----------|----------------|---------|
+| **Thinking patterns** | Reasoning approaches that worked/failed | "Tree-of-thought for multi-approach decisions in auth" |
+| **Coding rules** | Code standards discovered during implementation | "Always validate JWT expiry before checking claims" |
+| **Project rules** | Codebase conventions the agent should follow | "This project uses barrel exports — add to index.ts" |
+| **Quality checks** | New checklist items from bugs or review findings | "Auth features need rate limiting check" |
+| **Process rules** | Workflow improvements from the session | "Run integration tests before unit tests in this project" |
+
+For each learning, check:
+
+| Check | If Yes |
+|-------|--------|
+| Already exists in user/project rules? | SKIP (don't duplicate) |
+| Contradicts an existing rule? | FLAG as conflict |
+| Universal or project-specific? | Determines target level |
+| Actionable in 1-2 lines? | If not, refine |
+
+## Step 3: Classify & Target
+
+| Learning Type | Target Level | Where to Add |
+|---------------|-------------|--------------|
+| Thinking pattern (universal) | User-level | Rules file: reasoning/mental-models |
+| Thinking pattern (project) | Project-level | Project rules file |
+| Coding rule (universal) | User-level | Rules file: coding standards |
+| Coding rule (language-specific) | User-level | Rules file: coding-{language} |
+| Coding rule (project-specific) | Project-level | Project rules or CLAUDE.md |
+| Project convention | Project-level | Project rules file |
+| Quality check | Project-level | Quality checklist or rules file |
+| Process rule (universal) | User-level | Rules file: workflow/process |
+| Process rule (project) | Project-level | Project rules file |
+
+## Step 4: Propose
+
+Present to user for approval:
+
+    ### Proposed Memory Updates
+
+    Based on this session, I suggest updating your agent config:
+
+    **Thinking Patterns:**
+    - [user-level] {pattern}: {when to apply} → Add to {file}
+    - [project-level] {pattern}: {when to apply} → Add to {file}
+
+    **Coding Rules:**
+    - [project-level] {rule}: {rationale} → Add to {file}
+
+    **Quality Checks:**
+    - [project-level] {check}: {what it catches} → Add to {file}
+
+    **Process Rules:**
+    - [user-level] {rule}: {why it helps} → Add to {file}
+
+    **Conflicts with existing rules:**
+    - {existing rule} vs {proposed rule}: {recommendation}
+
+    Update? [apply all / select / skip]
+
+## Agent Config Targets
+
+| Agent | User-level | Project-level |
+|-------|-----------|--------------|
+| Claude Code | `~/.claude/CLAUDE.md` or `~/.claude/rules/{topic}.md` | `{project}/.claude/CLAUDE.md` or `{project}/.claude/rules/*.md` |
+| Cursor | `~/.cursorrules` | `{project}/.cursorrules` |
+| Windsurf | `~/.windsurfrules` | `{project}/.windsurfrules` |
+| Aider | `~/.aider.conf.yml` | `{project}/.aider.conf.yml` |
+| Continue | `~/.continue/config.json` | `{project}/.continue/config.json` |
+| Codex | Agent config | Project config |
+| Other | Ask user for path | Ask user for path |
+
+Auto-detect which agent is running. If unknown, ask the user where to write.
+
+## Rules
+
+- **Read before proposing** — ALWAYS read existing rules first. No blind proposals.
+- ALWAYS propose, NEVER auto-write. User approves every memory update.
+- Keep updates concise: 1-2 lines per learning, actionable.
+- **No duplicates** — skip if learning already exists in rules.
+- **Flag conflicts** — if proposed rule contradicts existing, present both and recommend.
+- Prefer project-level for project-specific knowledge.
+- Prefer user-level for universal patterns.
+- Max 5 proposals per session — prioritize by impact.
+- Configurable: edit this file to disable memory update proposals.

--- a/workflow/references/patterns/debugging.md
+++ b/workflow/references/patterns/debugging.md
@@ -1,0 +1,130 @@
+# Debugging Patterns
+
+## Scientific Method
+
+Hypothesis-driven debugging. No random changes.
+
+**When:** Any non-trivial bug. Default approach.
+
+```
+Phase 1: SYMPTOM CAPTURE
+  - Exact error message/behavior
+  - Steps to reproduce
+  - When it started (last known good state)
+  - Environment details
+
+Phase 2: HYPOTHESIS FORMATION
+  Rank by likelihood:
+  H1: {most likely cause} (probability: X%)
+  H2: {second most likely} (probability: Y%)
+  H3: {least likely} (probability: Z%)
+
+Phase 3: TEST HYPOTHESES
+  For each hypothesis (highest probability first):
+    Design minimal test that proves/disproves
+    Execute test
+    Record result: CONFIRMED / ELIMINATED
+    If confirmed → Phase 5
+    If eliminated → next hypothesis
+
+Phase 4: BINARY SEARCH (if no hypothesis confirmed)
+  git bisect or manual binary elimination:
+    Find last known good commit
+    Bisect to identify breaking change
+
+Phase 5: ROOT CAUSE CONFIRMATION
+  - Can you explain WHY it broke, not just WHERE?
+  - Does the fix make the reproduction case pass?
+  - Are there related occurrences of the same pattern?
+```
+
+**Key rule:** Never make a change without a hypothesis for why it will fix the bug.
+
+---
+
+## Root Cause Analysis
+
+Go deeper than the immediate fix. Prevent recurrence.
+
+**When:** Bug keeps coming back, systemic issues, post-incident review.
+
+### 5 Whys
+
+```
+Problem: {symptom}
+Why 1: {immediate cause}
+Why 2: {cause of cause}
+Why 3: {deeper cause}
+Why 4: {systemic cause}
+Why 5: {root cause}
+→ Fix at level 4-5, not level 1
+```
+
+### Fishbone (Ishikawa) Diagram
+
+```
+                    ┌──── Code ────── {cause}
+                    ├──── Data ────── {cause}
+{symptom} ◄─────────┤
+                    ├──── Environment ── {cause}
+                    ├──── Config ───── {cause}
+                    └──── External ─── {cause}
+```
+
+**Root cause test:** If you fix this, does the problem NEVER recur? If not, dig deeper.
+
+**Contributing causes:** Multiple factors that must all be present. Fix any one to prevent.
+
+---
+
+## Minimal Reproduction
+
+Reduce the problem to its smallest form.
+
+**When:** Complex bugs, hard to isolate, environment-dependent issues.
+
+```
+Strategy: BINARY REMOVAL
+1. Start with full reproduction case
+2. Remove half the code/config/data
+3. Bug still present? Remove another half of remaining
+4. Bug gone? Restore last removal, remove other half
+5. Repeat until minimal case found
+```
+
+**Reproduction patterns by bug type:**
+
+| Bug Type | Isolation Technique |
+|----------|-------------------|
+| UI rendering | Single component in isolation (Storybook) |
+| API error | Standalone request (curl/httpie) |
+| State bug | Minimal state + single action |
+| Race condition | Add delays to force ordering |
+| Data corruption | Minimal dataset that triggers issue |
+| Environment | Docker/devcontainer with minimal config |
+
+---
+
+## Instrumentation Patterns
+
+Add observability to understand behavior.
+
+**When:** Bug not reproducible, need runtime evidence, production debugging.
+
+**4 levels:**
+
+| Level | What | When |
+|-------|------|------|
+| 1. Console | console.log/print at key points | Quick local debugging |
+| 2. Structured | JSON logs with context (request ID, user, timestamp) | Multi-step flows |
+| 3. Tracing | Span-based tracing across functions/services | Distributed systems |
+| 4. Metrics | Counters, histograms, gauges | Performance/capacity issues |
+
+**Strategic placement:**
+- Function entry/exit with arguments and return values
+- Branch points (which path was taken?)
+- External calls (request + response + timing)
+- State mutations (before + after)
+- Error catch blocks (full context)
+
+**Cleanup rule:** Remove debug instrumentation before committing. Use feature flags for persistent observability.

--- a/workflow/references/patterns/decisions.md
+++ b/workflow/references/patterns/decisions.md
@@ -1,0 +1,104 @@
+# Decision Patterns
+
+## Second-Order Thinking
+
+Think 2-3 steps ahead. "And then what?"
+
+**When:** Architecture decisions, technology choices, process changes.
+
+```
+Decision: {what you're choosing}
+
+First-order effects (immediate):
+  + {benefit}
+  - {cost}
+
+Second-order effects (weeks later):
+  + {downstream benefit}
+  - {downstream cost}
+
+Third-order effects (months later):
+  + {compounding benefit}
+  - {compounding cost}
+```
+
+**Template:**
+```markdown
+| Order | Positive | Negative |
+|-------|----------|----------|
+| 1st (now) | {immediate win} | {immediate cost} |
+| 2nd (weeks) | {downstream win} | {downstream cost} |
+| 3rd (months) | {compounding win} | {compounding cost} |
+```
+
+**Common traps:**
+- Optimizing for first-order only (short-term thinking)
+- Ignoring negative second-order effects (hidden costs)
+- Assuming positive effects compound but negative ones don't
+
+---
+
+## Reversibility Test
+
+Classify decisions as one-way or two-way doors.
+
+**When:** Any significant technical decision. Default mental model.
+
+**Type 1 (one-way door):** Irreversible or very costly to reverse.
+- Database schema in production with data
+- Public API contract with external consumers
+- Framework/language choice for large codebase
+- Deleting user data
+
+→ **Slow down.** Gather more information. Get review. Prototype first.
+
+**Type 2 (two-way door):** Easily reversible, low cost to change.
+- Internal API design (refactorable)
+- UI layout (shippable, measurable)
+- Library choice for isolated feature
+- Feature flag rollout
+
+→ **Decide fast.** Ship, measure, adjust. Don't over-analyze.
+
+**Classification questions:**
+1. What does it cost to reverse this? (hours? days? weeks?)
+2. Who is affected if we reverse? (just us? users? partners?)
+3. Is data involved? (data migrations are expensive)
+4. Are external contracts involved? (APIs, integrations)
+
+**Effort matching:**
+```
+Type 1: hours of analysis → days of implementation
+Type 2: minutes of analysis → hours of implementation
+```
+
+---
+
+## Opportunity Cost
+
+Every choice excludes alternatives. What are you NOT doing?
+
+**When:** Prioritization, resource allocation, scope decisions.
+
+```
+Option A: {what you'd do}
+  Value: {expected outcome}
+  Cost: {time + resources}
+  Value/hour: {value ÷ hours}
+
+Option B: {alternative}
+  Value: {expected outcome}
+  Cost: {time + resources}
+  Value/hour: {value ÷ hours}
+
+Opportunity cost of A = Value of best alternative not chosen
+```
+
+**Common traps:**
+- **Sunk cost:** "We already spent 3 days on this" → Irrelevant. Only future costs matter.
+- **Urgency bias:** "This is urgent!" → Urgent ≠ important. What's the actual deadline?
+- **Completion bias:** "We're 80% done" → Is the remaining 20% worth finishing vs switching?
+- **Default bias:** "We've always done it this way" → Is there a better way now?
+
+**Quick test:** "If I hadn't started this, would I start it today given what I know now?"
+If no → consider dropping (see `actions/drop.md`).

--- a/workflow/references/patterns/decomposition.md
+++ b/workflow/references/patterns/decomposition.md
@@ -1,0 +1,114 @@
+# Decomposition Patterns
+
+## First Principles
+
+Break to fundamentals. Challenge assumptions. Rebuild from ground truth.
+
+**When:** Novel problems, inherited constraints, "we've always done it this way."
+
+```
+1. IDENTIFY the problem clearly (one sentence)
+2. LIST all assumptions
+3. CHALLENGE each: Is this a law of physics or a convention?
+   - Law of physics: keep (e.g., "network calls have latency")
+   - Convention: question (e.g., "we need a separate auth service")
+4. REBUILD from only the validated fundamentals
+```
+
+**Example:**
+```
+Problem: "Auth takes 500ms on every request"
+Assumptions:
+  ✓ Auth is required (law — security requirement)
+  ✗ Auth must hit the database (convention — can use JWT/cache)
+  ✗ Auth must happen per-request (convention — can use sessions)
+  ✓ Token must be validated (law — security)
+Rebuild: Validate JWT locally (no DB call), cache sessions → 5ms
+```
+
+**Key rule:** Most constraints are inherited conventions, not physical laws. Test them.
+
+---
+
+## Inversion
+
+"What would guarantee failure?" Prevent those things.
+
+**When:** Risk assessment, pre-mortems, defensive design, quality checklists.
+
+```
+1. Define success: {what you want to achieve}
+2. Invert: "How do I guarantee this FAILS?"
+   List 5-10 failure modes
+3. For each failure mode:
+   - How likely is it? (HIGH/MEDIUM/LOW)
+   - How would we detect it?
+   - How do we prevent it?
+4. Build prevention into the plan
+```
+
+**Example:**
+```
+Success: "Reliable payment processing"
+Guaranteed failure modes:
+  1. No idempotency → duplicate charges → Add idempotency keys
+  2. No timeout → hung requests → Add 30s timeout + retry
+  3. No validation → bad amounts → Validate at boundary
+  4. No logging → can't debug → Structured logging on all paths
+  5. No rollback → partial state → Transaction wrapper
+```
+
+**Use for quality checklists:** Invert each scope item → "what breaks this?" → checklist item.
+
+---
+
+## MECE (Mutually Exclusive, Collectively Exhaustive)
+
+Decompose without gaps or overlaps.
+
+**When:** Problem decomposition, scope breakdown, categorization, test coverage.
+
+```
+MECE test:
+  ME (Mutually Exclusive): No item belongs in two categories
+  CE (Collectively Exhaustive): Every case is covered by some category
+```
+
+**How to MECE-decompose:**
+
+```
+1. Pick a dimension to split on (user type, data flow, lifecycle stage)
+2. List categories along that dimension
+3. ME test: Can any item fit in 2+ categories? → refine boundaries
+4. CE test: Can you think of something not covered? → add category
+```
+
+**Common MECE frameworks:**
+
+| Framework | Split By | Example |
+|-----------|----------|---------|
+| User lifecycle | Stage | Acquire → Activate → Retain → Revenue → Refer |
+| Data flow | Direction | Input → Process → Output → Store |
+| Error handling | Severity | Fatal → Recoverable → Warning → Info |
+| Feature scope | Layer | Data → Logic → API → UI → Test |
+| Time | Phase | Before → During → After |
+
+**Anti-patterns:**
+- Overlapping categories (item fits in 2 buckets)
+- Missing the "other" bucket (edge cases uncovered)
+- Too many categories (>7 = too granular, re-group)
+- Too few categories (2-3 = probably missing nuance)
+
+**Application to scope breakdown:**
+```
+Feature: User authentication
+MECE by flow:
+  1. Registration (new user → account created)
+  2. Login (credentials → session)
+  3. Session management (active → expired → refresh)
+  4. Logout (session → destroyed)
+  5. Recovery (forgot password → reset → login)
+
+ME check: Each flow is distinct, no overlap ✓
+CE check: All auth states covered ✓
+```

--- a/workflow/references/patterns/implementation.md
+++ b/workflow/references/patterns/implementation.md
@@ -1,0 +1,102 @@
+# Implementation Patterns
+
+## Tracer Bullet
+
+Build minimal end-to-end path first, then expand each layer.
+
+**When:** Greenfield features, unknown integration points, proving architecture.
+
+```
+1. Identify the thinnest possible E2E path (DB → API → UI)
+2. Build hardcoded/stubbed version that works end-to-end
+3. Replace stubs with real implementation, one layer at a time
+4. Each step: working software, not just working layer
+```
+
+**Template:**
+```
+Tracer: {feature} — thinnest E2E path
+  Layer 1 (data): {hardcoded response}
+  Layer 2 (API): {stub endpoint returning hardcoded}
+  Layer 3 (UI): {display hardcoded data}
+  → Verify E2E works
+  → Replace Layer 1 with real DB query
+  → Replace Layer 2 with real logic
+  → Replace Layer 3 with real components
+```
+
+**Key rule:** Every step produces working software. Never build a layer in isolation.
+
+---
+
+## Vertical Slice
+
+Complete one feature fully across all layers before starting the next.
+
+**When:** Multiple features to build, cross-layer dependencies, team handoffs.
+
+```
+Feature A: DB schema → API endpoint → UI component → tests → DONE
+Feature B: DB schema → API endpoint → UI component → tests → DONE
+(NOT: all DB schemas → all APIs → all UIs)
+```
+
+**Good slice boundaries:**
+- User-visible behavior change
+- Independently deployable
+- Has its own test cases
+- Can be demo'd
+
+**Bad slice boundaries:**
+- "All the database work"
+- "The API layer"
+- "Frontend only" (unless pure UI)
+
+---
+
+## Strangler Fig
+
+Gradually replace legacy system via facade routing.
+
+**When:** Legacy replacement, large migrations, can't rewrite at once.
+
+```
+1. Create facade (proxy/router) in front of legacy system
+2. Route first feature to new implementation
+3. Verify new implementation matches legacy behavior
+4. Route more features to new implementation
+5. When all features migrated, remove legacy + facade
+```
+
+**Routing strategies:**
+- Feature flag: toggle per feature
+- Percentage: 10% → 50% → 100%
+- User segment: internal → beta → all
+- Request type: reads first, then writes
+
+**Key rule:** Legacy and new system coexist. Never big-bang cutover.
+
+---
+
+## Inside-Out vs Outside-In
+
+Choose starting point based on where complexity lives.
+
+**Inside-out** (start from core logic, expand to boundaries):
+- When: Complex algorithms, data transformations, business rules
+- Pro: Core logic validated first
+- Con: Integration discovered late
+
+**Outside-in** (start from user interface, work inward):
+- When: UI-driven features, clear user flows, API-first design
+- Pro: User experience validated first
+- Con: Core logic deferred
+
+**Decision framework:**
+```
+Where is the complexity?
+  Core logic/algorithm → Inside-out
+  User interaction/flow → Outside-in
+  Both equally complex → Meet in the middle
+    (define interface between layers, build both toward it)
+```

--- a/workflow/references/patterns/planning.md
+++ b/workflow/references/patterns/planning.md
@@ -1,0 +1,96 @@
+# Planning Patterns
+
+## Working Backwards
+
+Start from the end state, work backward to tasks. (Amazon PR/FAQ method.)
+
+**When:** Unclear requirements, stakeholder alignment needed, outcome-driven features.
+
+```
+1. Write the announcement: "We shipped {feature}. It does {X}."
+2. Define "True When": List 3-5 testable statements that prove it works
+3. Gap analysis: What exists today vs what's needed?
+4. Work backward: From gaps → tasks → dependencies → order
+5. FAQ: Answer likely questions (technical, user, business)
+```
+
+**Template:**
+```markdown
+## Announcement
+We shipped {feature}. Users can now {capability}.
+
+## True When
+- [ ] User can {action} and see {result}
+- [ ] System handles {edge case} gracefully
+- [ ] Performance: {metric} under {threshold}
+
+## Gaps (current → needed)
+- {what exists} → {what's needed} → {task}
+
+## FAQ
+Q: Why not {alternative}?
+A: {reason}
+```
+
+---
+
+## Constraint Mapping
+
+Identify fixed vs flexible constraints before planning.
+
+**When:** Hard deadlines, resource limits, regulatory requirements, unclear boundaries.
+
+```
+1. List ALL constraints (technical, time, budget, legal, people)
+2. Classify each: FIXED (can't change) vs FLEXIBLE (can negotiate)
+3. Challenge "fixed" constraints: Is this truly immovable?
+4. Build plan around fixed constraints, optimize flexible ones
+```
+
+**Iron triangle:** Scope, Time, Quality — pick 2, the third adjusts.
+
+**Common false constraints:**
+- "We need all features for launch" → Do we? MVP?
+- "It has to use {technology}" → Why? What problem does it solve?
+- "We need it by Friday" → What happens if Monday? What's the real deadline?
+
+**Negotiability matrix:**
+```
+              Can't Change    Can Negotiate
+High Impact   [FIXED]         [OPTIMIZE]
+Low Impact    [ACCEPT]        [IGNORE]
+```
+
+---
+
+## Risk-First Planning
+
+Order work by risk, not by ease or dependency.
+
+**When:** High-uncertainty projects, new technology, tight deadlines.
+
+```
+1. List risks (technical, schedule, scope, external)
+2. Score each: Impact (1-5) × Likelihood (1-5)
+3. Order work: highest risk score first
+4. Define kill criteria: "If {condition}, abandon this approach"
+5. Spike pattern: time-boxed exploration before committing
+```
+
+**Risk categories:**
+- Technical: "Can we even build this?"
+- Integration: "Will it work with {system}?"
+- Performance: "Will it be fast enough?"
+- Scope: "Is the scope realistic?"
+- External: "Will the API/service/team deliver?"
+
+**Spike pattern:**
+```
+Spike: {question to answer}
+Time box: {hours}
+Success: {what we'd learn/prove}
+Kill criteria: {when to stop and reconsider}
+Output: Go/no-go decision + evidence
+```
+
+**Key rule:** Attack the scariest unknown first. If it fails, fail early.

--- a/workflow/references/quality-gates.md
+++ b/workflow/references/quality-gates.md
@@ -1,0 +1,142 @@
+# Quality Gates
+
+> **Agent:** Load this file when `ship` runs quality gates. Also referenced by `done` for full validation.
+
+Two-pass validation. No task complete until full pass green.
+
+## Quick Pass (After Each Edit Batch)
+
+Scope: changed files only. Run after each logical unit of edits.
+
+```
+Changed files → LINT → TYPECHECK → pass? → continue coding
+                 ↓ fail   ↓ fail
+                FIX       FIX (max 3 attempts → escalate)
+```
+
+## Full Pass (Before Task Complete — BLOCKING)
+
+Scope: full project. All 4 gates must pass.
+
+```
+LINT (changed) → TYPECHECK (full) → BUILD (full) → TEST (related)
+```
+
+Gate order rationale: cheapest/fastest first. Each catches a superset of earlier failures.
+
+| Gate | Scope | Why |
+|------|-------|-----|
+| Lint | Changed files | Fast — catches style/syntax |
+| Typecheck | Full project | Catches broken consumers of changed exports |
+| Build | Full project | Dependency graph requires full compilation |
+| Test | Related tests | Match changed files to their test files |
+
+## Stack Auto-Detection
+
+Detect tooling from project files. Never hardcode commands.
+
+### Package Manager
+
+| Lockfile | Manager |
+|----------|---------|
+| pnpm-lock.yaml | pnpm |
+| yarn.lock | yarn |
+| bun.lockb | bun |
+| package-lock.json | npm |
+
+### Lint Tool
+
+| Config | Tool |
+|--------|------|
+| biome.json / biome.jsonc | biome check |
+| .eslintrc* / eslint.config.* | eslint |
+| deno.json | deno lint |
+| ruff.toml / pyproject.toml (ruff) | ruff check |
+| .golangci.yml | golangci-lint run |
+| .rubocop.yml | rubocop |
+| phpcs.xml / .php-cs-fixer.php | phpcs / php-cs-fixer |
+| .swiftlint.yml | swiftlint |
+| detekt.yml / .editorconfig (ktlint) | detekt / ktlint |
+
+### Build Tool
+
+| Config | Tool |
+|--------|------|
+| package.json (scripts.build) | {pkg-manager} run build |
+| build.gradle / build.gradle.kts | gradle build |
+| pom.xml | mvn compile |
+| *.csproj / *.sln | dotnet build |
+| Makefile | make |
+| Cargo.toml | cargo build |
+| Package.swift | swift build |
+| mix.exs | mix compile |
+| Gemfile + Rakefile | bundle exec rake build |
+| composer.json | composer build (if script exists) |
+
+### Test Runner
+
+| Config | Runner |
+|--------|--------|
+| vitest.config.* | vitest run |
+| jest.config.* | jest |
+| pytest.ini / pyproject.toml (pytest) | pytest |
+| *_test.go | go test ./... |
+| Cargo.toml | cargo test |
+| build.gradle / build.gradle.kts | gradle test |
+| pom.xml | mvn test |
+| *.csproj (with test projects) | dotnet test |
+| Package.swift | swift test |
+| mix.exs | mix test |
+| Gemfile | bundle exec rspec / bundle exec rake test |
+| composer.json | composer test / phpunit |
+
+### Typecheck
+
+| Stack | Command |
+|-------|---------|
+| TypeScript | tsc --noEmit |
+| Python (typed) | mypy / pyright |
+| Java / Kotlin | (covered by build — compiler checks types) |
+| C# | (covered by dotnet build) |
+| Go | (covered by go build / go vet) |
+
+## Fix Loop Protocol
+
+Per gate, on failure:
+1. Read error output
+2. Fix the issue
+3. Re-run same gate
+4. Max 3 attempts → escalate to user with error output
+
+## Gate Levels
+
+All gates support three levels (edit this file to change):
+
+| Level | Behavior |
+|-------|----------|
+| BLOCKING | Must pass. Failure stops progress. |
+| ADVISORY | Warn on failure. Continue allowed. |
+| SKIP | Don't run this gate at all. |
+
+Default: all built-in gates are BLOCKING. Override in config:
+
+```markdown
+### Quality Gates (Full Pass)
+
+| Gate | Level | Command Override |
+|------|-------|-----------------|
+| Lint (changed files) | BLOCKING | |
+| Typecheck (full project) | SKIP | No TypeScript |
+| Build (full project) | BLOCKING | |
+| Test (related tests) | ADVISORY | Tests are flaky, fixing next sprint |
+```
+
+## Escape Hatch
+
+Skip a gate via:
+1. **Config:** Set gate level to SKIP in quality-gates.md
+2. **Flag:** `--skip-tests`, `--skip-review`
+3. **Auto-detect:** No tooling found for gate (no eslint config = skip lint)
+4. **User explicit:** User says "skip build" during session
+
+Always document skip reason in output.

--- a/workflow/references/session-management.md
+++ b/workflow/references/session-management.md
@@ -1,0 +1,167 @@
+# Session Management
+
+> **Agent:** Load this file when `ship` references session/resume/stuck logic. Also loaded by `done` for context reload.
+
+Track progress, detect stuck states, resume across sessions.
+
+## Progress Tracking
+
+Update spec after each iteration with a progress summary:
+
+```markdown
+## Progress
+
+| # | Scope Item | Status | Iteration |
+|---|-----------|--------|-----------|
+| 1 | {item} | [x] Complete | 2 |
+| 2 | {item} | [~] In progress | 3 |
+| 3 | {item} | [ ] Pending | - |
+| 4 | {item} | [!] Blocked | 3 |
+
+**Iteration:** 3/8 | **Progress:** 1/4 (25%) | **Quality:** lint OK, types OK
+```
+
+Status markers:
+- `[ ]` Pending
+- `[~]` In progress
+- `[x]` Complete
+- `[!]` Blocked (with reason)
+
+## State Detection (On Resume)
+
+When `ship` is invoked, detect current state:
+
+```
+1. Active spec exists in specs/active/?
+   NO → FRESH (new work)
+   YES → continue
+
+2. Progress section has completed items?
+   NO → FRESH (spec created but no work done)
+   YES → continue
+
+3. Check iteration count and progress ratio
+   iteration >= stuck_threshold AND progress < 50%?
+   YES → STUCK
+   NO → continue
+
+4. All scope items [x]?
+   YES → READY_FOR_DONE
+   NO → RESUMING
+```
+
+| State | Action |
+|-------|--------|
+| FRESH | Start from beginning |
+| RESUMING | Resume from last incomplete scope item |
+| STUCK | Present escalation options to user |
+| READY_FOR_DONE | Suggest `done` |
+
+## Resume Protocol
+
+When RESUMING:
+
+```
+1. Read spec Progress section
+2. Find first non-[x] scope item
+3. Load context: what was last worked on, any notes
+4. Continue from that point
+5. Run quick quality pass before continuing implementation
+```
+
+## Context Reload Protocol
+
+When starting a new session or after context loss (compaction, session restart), reload context efficiently:
+
+```
+Priority order (read these first):
+
+1. SPEC FILE (source of truth)
+   Read: specs/active/{slug}.md
+   Get: scope, ACs, progress, notes, encountered bugs
+   This tells you WHAT to build and WHERE you left off.
+
+2. RECENT CHANGES
+   Run: git diff (staged + unstaged)
+   Run: git log --oneline -5
+   This tells you WHAT was recently changed.
+
+3. PROJECT CONFIG
+   Read: skill reference files (quality-gates.md, action files)
+   This tells you HOW quality gates and reviews are configured.
+
+4. CHANGED FILES (only the ones in progress)
+   Read files listed in Progress as [~] in-progress
+   This gives you CODE CONTEXT for the current task.
+
+5. TEST FILES (if mid-implementation)
+   Read test files related to changed code
+   This tells you what's TESTED and what's not.
+
+DO NOT re-read:
+  - Pattern references (load only when stuck)
+  - Action references (you know the workflow)
+  - All source files (only read what progress says is relevant)
+```
+
+### Context Summary Format
+
+When resuming, output a brief context summary before continuing:
+
+```markdown
+## Resuming: {spec title}
+**Progress:** {N}/{total} scope items complete
+**Current:** Working on scope item {N}: {description}
+**Last action:** {what was done last}
+**Next:** {what to do next}
+**Quality status:** lint {ok/fail}, types {ok/fail}
+```
+
+## Stuck Detection
+
+**Metrics tracked per iteration:**
+- Scope items completed (delta from last iteration)
+- Quality gate results (improving or regressing?)
+- Review blockers (decreasing or stable?)
+- Time in current iteration
+
+**Escalation triggers:**
+
+| Level | Trigger | Action |
+|-------|---------|--------|
+| Warning | At stuck_threshold, progress < 50% | Log warning, continue |
+| Pause | 2 more iterations, no progress | Present options to user |
+| Hard stop | At max_iterations | Force exit with summary |
+
+**Stuck recovery options (presented at Pause):**
+1. **Continue** — try a different approach to the current blocker
+2. **Reduce scope** — cut remaining items, ship what's done
+3. **Defer** — save state, come back later (`ship` will resume)
+4. **Drop** — abandon entirely (triggers `drop` action)
+
+## Token Budget
+
+Loading the full skill consumes tokens. Be intentional about what you load.
+
+| Tier | Estimated load | What to load |
+|------|---------------|--------------|
+| trivial | ~1K tokens | SKILL.md only — implement directly |
+| micro | ~2K tokens | SKILL.md + inline spec |
+| mini | ~8K tokens | SKILL.md + action file + spec-template (mini) |
+| standard | ~15K tokens | SKILL.md + action file + spec-template + quality-gates |
+
+**Token-saving strategies:**
+- Load action files on-demand (only when action triggers), not upfront
+- Load patterns only when stuck — they're reference material, not required reading
+- Skip output templates if using default format
+- For trivial/micro tiers: SKILL.md alone has enough to execute
+- If token-constrained mid-session: summarize spec progress, drop pattern references
+
+**Rule:** Never load all 21 files at once. The routing table in SKILL.md tells you which file to load next.
+
+## Prevention Tips
+
+- Break large scope items into smaller pieces
+- Run quality gates frequently (don't accumulate issues)
+- Address blockers immediately, don't work around them
+- If the same review issue appears 3 times, step back and rethink the approach

--- a/workflow/references/spec-template.md
+++ b/workflow/references/spec-template.md
@@ -1,0 +1,440 @@
+# Spec Template (SINGLE SOURCE OF TRUTH)
+
+> **Agent:** Load this file when `plan` triggers. Follow generation order exactly — each section feeds the next.
+
+This file defines the spec structure, generation rules, and validation. All spec creation follows this template exactly. `plan.md` orchestrates WHEN — this file defines WHAT.
+
+Save specs to: `specs/active/{YYYY-MM-DD}-{slug}.md`
+
+---
+
+## Generation Order
+
+Sections MUST be generated in this order. Each section feeds the next.
+
+```
+1. Context           ← from user input
+2. Codebase Impact   ← from reading the actual codebase (MANDATORY)
+3. User Journey      ← from context + codebase understanding (MANDATORY)
+4. Acceptance Criteria ← derived from journey steps (MANDATORY)
+5. Scope             ← derived from ACs + codebase impact
+6. Quality Checklist ← derived from scope + codebase patterns
+7. Risks             ← from codebase impact + pre-mortem
+8. State Machine     ← if stateful (from journey analysis)
+9. Analysis          ← improvements, gaps, questions (MANDATORY output)
+```
+
+**Rule: Never skip ahead. Journey drives ACs. ACs drive scope. Codebase drives everything.**
+
+---
+
+## Template Sections
+
+Each section below shows: the template (what goes in the spec) then the generation rules (how to write it).
+
+<!-- TEMPLATE: Front Matter + Context -->
+
+### Section: Front Matter + Context
+
+**Spec output:**
+
+    ---
+    title: {Feature Title}
+    status: active
+    created: {YYYY-MM-DD}
+    estimate: {N}h
+    tier: {trivial|micro|mini|standard}
+    ---
+
+    # {Feature Title}
+
+    ## Context
+
+    {Why this feature exists. What problem it solves. 2-3 sentences max.}
+
+**Generation rules:**
+- Extract from user input: WHAT (feature), WHY (problem), WHO (persona)
+- If user didn't state WHY → ask or infer and note the assumption
+
+---
+
+<!-- TEMPLATE: Codebase Impact -->
+
+### Section: Codebase Impact
+
+**Spec output:**
+
+    ## Codebase Impact (MANDATORY)
+
+    | Area | Impact | Detail |
+    |------|--------|--------|
+    | {file/module/area} | CREATE | {what and why} |
+    | {file/module/area} | MODIFY | {what changes and why} |
+    | {file/module/area} | AFFECTED | {indirect impact — consumers, imports, tests} |
+
+    **Files:** {N} create | {N} modify | {N} affected
+    **Reuse:** {existing patterns, utils, hooks, middleware, schemas to leverage — or "None identified"}
+    **Breaking changes:** {none / list with migration path}
+    **New dependencies:** {none / package name + justification + alternatives considered}
+
+**Generation rules:**
+- **MANDATORY: Read the codebase before writing anything else.**
+- Search for related code: grep keywords, read affected files, check existing patterns
+- Map every file that will be created, modified, or indirectly affected
+- Identify code to reuse — never reinvent what exists
+- Flag breaking changes to exports, APIs, schemas, config
+- Flag new dependencies with justification
+- **If agent hasn't read the codebase → spec is NOT_READY**
+- **Fallback:** If code search tools are unavailable, ask the user to provide affected file paths and existing patterns
+
+---
+
+<!-- TEMPLATE: User Journey -->
+
+### Section: User Journey
+
+**Spec output:**
+
+    ## User Journey (MANDATORY)
+
+    ### Primary Journey
+
+    ACTOR: {who — user type/persona}
+    GOAL: {what they want to accomplish}
+    PRECONDITION: {what must be true before starting}
+
+    1. User {action}
+       → System {response}
+       → User sees {outcome}
+
+    2. User {action}
+       → System {response}
+       → User sees {outcome}
+
+    3. User {action}
+       → System {response}
+       → User sees {final outcome}
+
+    POSTCONDITION: {what is now true}
+
+    ### Error Journeys
+
+    E1. {Error scenario name}
+       Trigger: {what goes wrong}
+       1. User {action}
+          → System {detects error}
+          → User sees {error message/state}
+       2. User {recovery action}
+          → System {recovers}
+       Recovery: {end state after recovery}
+
+    E2. {Error scenario name}
+       Trigger: {what goes wrong}
+       ...
+
+    ### Edge Cases
+
+    EC1. {Edge case}: {what happens}
+    EC2. {Edge case}: {what happens}
+
+**Generation rules:**
+- Write BEFORE scope — journey drives scope, not the other way around
+- Informed by codebase impact: what does the system already do? What's changing?
+- Primary journey: happy path from start to finish
+- Error journeys: at least 1 required (BLOCKING)
+- Edge cases: empty inputs, boundaries, concurrent users, permissions
+- Be specific: "{user sees error toast with message}" not "{user sees error}"
+- ACTOR/GOAL/PRECONDITION/POSTCONDITION are all required
+
+---
+
+<!-- TEMPLATE: Acceptance Criteria -->
+
+### Section: Acceptance Criteria
+
+**Spec output:**
+
+    ## Acceptance Criteria (MANDATORY)
+
+    ### Must Have (BLOCKING — all must pass to ship)
+
+    - [ ] AC-1: GIVEN {context from journey step} WHEN {action} THEN {observable result}
+    - [ ] AC-2: GIVEN {context} WHEN {action} THEN {result}
+    - [ ] AC-3: GIVEN {context} WHEN {action} THEN {result}
+
+    ### Error Criteria (BLOCKING — all must pass)
+
+    - [ ] AC-E1: GIVEN {error context from E1} WHEN {trigger} THEN {graceful handling}
+    - [ ] AC-E2: GIVEN {error context} WHEN {trigger} THEN {handling}
+
+    ### Should Have (ship without, fix soon)
+
+    - [ ] AC-4: GIVEN {nice-to-have context} WHEN {action} THEN {result}
+
+**Generation rules:**
+- Derive directly from user journey — every journey step → at least 1 AC
+- Every error journey → at least 1 AC-E
+- Format: GIVEN/WHEN/THEN — no exceptions
+- Every AC must be pass/fail — no ambiguity, no "should feel smooth"
+- Every AC must be testable (manual or automated)
+- Minimum: 1 Must Have AC + 1 Error Criterion
+- ACs are the EXIT GATE for `ship` — work is DONE when all Must Have + Error ACs pass
+
+---
+
+<!-- TEMPLATE: Scope -->
+
+### Section: Scope
+
+**Spec output:**
+
+    ## Scope
+
+    - [ ] 1. {First deliverable — verb + noun} → AC-1, AC-2
+    - [ ] 2. {Second deliverable} → AC-3
+    - [ ] 3. {Third deliverable} → AC-E1, AC-E2
+
+    ### Out of Scope
+
+    - {What this feature does NOT include — set boundaries}
+
+**Generation rules:**
+- Derive from ACs + codebase impact — scope items are implementation tasks
+- Each item: verb + noun + measurable outcome
+- Each item MUST map to at least 1 AC (no orphan scope)
+- Each Must Have AC MUST map to at least 1 scope item (no uncovered AC)
+- Inform by codebase: if existing code handles part of it, scope is smaller
+- Out of Scope: explicitly state what's NOT included to prevent scope creep
+
+**Traceability Check (BLOCKING):**
+
+```
+orphan_scope = scope items with no AC mapping     → CUT
+uncovered_ac = Must Have ACs with no scope item    → ADD scope item
+Result: every scope ↔ at least 1 AC, bidirectional
+```
+
+---
+
+<!-- TEMPLATE: Quality Checklist -->
+
+### Section: Quality Checklist
+
+**Spec output:**
+
+    ## Quality Checklist
+
+    ### Blocking (must pass to ship)
+
+    - [ ] All Must Have ACs passing
+    - [ ] All Error Criteria ACs passing
+    - [ ] All scope items implemented
+    - [ ] No regressions in existing tests
+    - [ ] Error states handled (not just happy path)
+    - [ ] No hardcoded secrets or credentials
+    - [ ] {Domain-specific blocking item from codebase analysis}
+
+    ### Advisory (should pass, not blocking)
+
+    - [ ] All Should Have ACs passing
+    - [ ] Code follows existing project patterns
+    - [ ] {Domain-specific advisory item}
+
+**Generation rules:**
+- Always include the 6 baseline blocking items above
+- Add domain-specific items using Socratic questions per scope item:
+  - "What would make this FAIL in production?"
+  - "What edge case would a user hit first?"
+  - "What would break if this input were empty/null/huge?"
+- Informed by codebase: what patterns does this project enforce?
+- Mark each item `[blocking]` or `[advisory]`
+
+---
+
+<!-- TEMPLATE: Risks -->
+
+### Section: Risks
+
+**Spec output:**
+
+    ## Risks
+
+    | Risk | Impact | Likelihood | Mitigation |
+    |------|--------|------------|------------|
+    | {risk from codebase impact} | HIGH/MED/LOW | HIGH/MED/LOW | {mitigation} |
+    | {risk from pre-mortem} | HIGH/MED/LOW | HIGH/MED/LOW | {mitigation} |
+
+    **Kill criteria:** {When to abandon this approach entirely}
+
+**Generation rules (standard tier):**
+- Pre-mortem: assume the feature failed — why?
+- Informed by codebase: breaking changes, migration risks, dependency risks
+- Every HIGH risk MUST have a mitigation
+- Kill criteria: define when to stop and rethink
+
+---
+
+<!-- TEMPLATE: State Machine -->
+
+### Section: State Machine
+
+**Spec output:**
+
+    ## State Machine
+
+    {For stateful features only. Delete section if stateless.}
+
+    ┌────────┐   event    ┌─────────┐
+    │ STATE1 │───────────▶│ STATE2  │
+    └────────┘            └─────────┘
+
+    States: {list with data shapes}
+    Transitions: {triggers + guards}
+    Invalid transitions: {prevention strategy}
+    Race conditions: {analysis}
+
+**Generation rules:**
+- Required for stateful features (forms, wizards, async flows, status tracking)
+- Stateless features: delete section or write "N/A — stateless feature"
+- Include ASCII transition diagram
+- Map all valid + invalid transitions
+
+---
+
+<!-- TEMPLATE: Analysis + Tracking -->
+
+### Section: Analysis + Tracking
+
+**Spec output:**
+
+    ## Analysis
+
+    ### Improvements
+    - {Suggestion to strengthen the spec, architecture, or approach}
+    - {Alternative approach worth considering}
+
+    ### Gaps
+    - {Unknown that could affect implementation}
+    - {Assumption that needs validation}
+
+    ### Questions
+    - {Question for the user — answer before ship or accept defaults}
+    - {Clarification needed on ambiguous aspect}
+
+    ## Notes
+
+    {Empty at creation. Filled during implementation. Retro goes here.}
+
+    ## Progress
+
+    | # | Scope Item | Status | Iteration |
+    |---|-----------|--------|-----------|
+
+    ## Timeline
+
+    | Action | Timestamp | Duration | Notes |
+    |--------|-----------|----------|-------|
+    | plan | {ISO_TIMESTAMP} | - | Created |
+
+**Generation rules (MANDATORY output):**
+- **Improvements**: proactive suggestions the user hasn't considered
+  - Better patterns, simpler approaches, existing code to leverage
+  - Architectural alternatives worth weighing
+- **Gaps**: unknowns that won't block dev but should be tracked
+  - Assumptions made that could be wrong
+  - Areas where requirements are ambiguous
+- **Questions**: things the agent can't resolve alone
+  - Preference decisions, business logic clarifications
+  - If no questions: "None — requirements are clear"
+- **Be proactive**: flag edge cases, perf concerns, security implications, UX issues the user hasn't mentioned
+
+---
+
+## Mini Tier Template
+
+For <100 LOC features. Same rules, shorter format. Codebase Impact + Journey + ACs still MANDATORY.
+
+**Spec output:**
+
+    ---
+    title: {Title}
+    status: active
+    created: {YYYY-MM-DD}
+    estimate: {N}h
+    tier: mini
+    ---
+
+    # {Title}
+
+    ## Codebase Impact
+
+    | Area | Impact | Detail |
+    |------|--------|--------|
+    | {area} | CREATE/MODIFY | {detail} |
+
+    **Reuse:** {what to leverage}
+
+    ## User Journey
+
+    1. User {action} → sees {result}
+    2. User {action} → sees {result}
+    Error: {what goes wrong} → sees {error state}
+
+    ## Acceptance Criteria
+
+    - [ ] AC-1: GIVEN {context} WHEN {action} THEN {result}
+    - [ ] AC-2: GIVEN {context} WHEN {action} THEN {result}
+    - [ ] AC-E1: GIVEN {error} WHEN {trigger} THEN {handling}
+
+    ## Scope
+
+    - [ ] 1. {deliverable} → AC-1
+    - [ ] 2. {deliverable} → AC-2
+
+    ## Quality Checklist
+
+    - [ ] All ACs passing
+    - [ ] No regressions
+    - [ ] Error states handled
+
+    ## Analysis
+
+    **Improvements:** {or "None"}
+    **Gaps:** {or "None"}
+    **Questions:** {or "None — requirements clear"}
+
+    ## Notes
+
+    ## Timeline
+
+    | Action | Timestamp | Duration | Notes |
+    |--------|-----------|----------|-------|
+    | plan | {ISO_TIMESTAMP} | - | Created |
+
+---
+
+## Validation Rules (BLOCKING for dev-readiness)
+
+A spec missing ANY of these cannot proceed to `ship`.
+
+| # | Rule | Check | Blocking |
+|---|------|-------|----------|
+| 1 | Codebase analyzed | `## Codebase Impact` is non-empty, files listed | YES |
+| 2 | Journey exists | `## User Journey` section is non-empty | YES |
+| 3 | Journey has actor + goal | ACTOR and GOAL defined | YES |
+| 4 | Journey has error path | At least 1 error journey (E1) | YES |
+| 5 | ACs exist | `## Acceptance Criteria` section is non-empty | YES |
+| 6 | ACs use GIVEN/WHEN/THEN | Every AC follows the format | YES |
+| 7 | ACs have Must Have | At least 1 Must Have AC | YES |
+| 8 | ACs have Error Criteria | At least 1 AC-E error criterion | YES |
+| 9 | Scope maps to ACs | Every scope item references an AC | YES |
+| 10 | ACs map to scope | Every Must Have AC is covered by scope | YES |
+| 11 | No orphan scope | Scope item with no AC mapping → cut | YES |
+| 12 | No uncovered AC | Must Have AC with no scope item → add scope | YES |
+| 13 | Analysis present | Improvements + Gaps + Questions sections exist | YES |
+
+---
+
+## Plan Output
+
+Follow the output template in `references/templates/plan-output.md`.

--- a/workflow/references/templates/done-output.md
+++ b/workflow/references/templates/done-output.md
@@ -1,0 +1,49 @@
+# Done Output Template
+
+Edit this file to customize what the agent returns after `done`. Decision logic: [actions/done.md](../actions/done.md).
+
+---
+
+## Validation Passed
+
+```markdown
+## Done: {title}
+
+**Spec:** `specs/shipped/{filename}`
+**Estimate vs Actual:** {X}h → {Y}h ({accuracy}%)
+
+### Validation
+- Must Have ACs: {N}/{N} PASS
+- Error ACs: {N}/{N} PASS
+- New tests: {N} added
+- Quality gates: lint OK | typecheck OK | build OK | test OK
+- Bugs: {N} fixed, {N} deferred
+
+### Retro
+- **Worked:** {insight}
+- **Didn't:** {insight with root cause}
+- **Next time:** {specific improvement}
+
+### Memory Update Proposed
+- **User-level:** {learning or "None"}
+- **Project-level:** {learning or "None"}
+
+### Next (human)
+1. Commit + push
+2. Deploy
+3. Verify in production
+```
+
+---
+
+## Validation Failed
+
+```markdown
+## Done: NOT READY
+
+**Failing checks:**
+- {check}: {what's wrong}
+- {check}: {what's wrong}
+
+Run `ship` to fix remaining issues.
+```

--- a/workflow/references/templates/drop-output.md
+++ b/workflow/references/templates/drop-output.md
@@ -1,0 +1,17 @@
+# Drop Output Template
+
+Edit this file to customize what the agent returns after `drop`. Decision logic: [actions/drop.md](../actions/drop.md).
+
+---
+
+```markdown
+## Dropped: {title}
+
+**Reason:** {category} — {details}
+**Time invested:** {hours}
+**Spec:** `specs/dropped/{filename}`
+
+**Reusable:** {what can be salvaged — or "Nothing"}
+**Key learning:** {most important insight}
+**If revisited:** {different approach to try}
+```

--- a/workflow/references/templates/plan-output.md
+++ b/workflow/references/templates/plan-output.md
@@ -1,0 +1,55 @@
+# Plan Output Template
+
+Edit this file to customize what the agent returns after `plan`. Decision logic: [actions/plan.md](../actions/plan.md).
+
+---
+
+```markdown
+## Plan Complete: {title}
+
+**Spec:** `specs/active/{filename}.md`
+**Status:** READY / CONDITIONAL / NOT_READY
+**Tier:** {tier} | **Estimate:** {X}h | **Scope:** {N} items
+
+### Codebase Impact
+
+| Area | Impact | Detail |
+|------|--------|--------|
+| {module} | CREATE/MODIFY/AFFECTED | {what and why} |
+
+**Reuse:** {existing code to leverage}
+**Breaking changes:** {none or list}
+
+### Analysis
+
+**Improvements:**
+- {suggestion to strengthen spec, architecture, or approach}
+
+**Gaps:**
+- {unknown that could affect implementation}
+
+**Questions:**
+- {question for user — or "None — requirements clear"}
+
+**Risks:**
+- {risk}: {mitigation}
+
+### Readiness
+
+| Gate | Result |
+|------|--------|
+| Codebase analyzed | PASS/FAIL |
+| User journey | PASS/FAIL |
+| Error journeys | PASS/FAIL |
+| Acceptance criteria | PASS/FAIL |
+| Scope ↔ AC traceability | PASS/FAIL |
+| Quality checklist | PASS/FAIL |
+| Analysis complete | PASS/FAIL |
+
+**Score:** {N}/{max} | **Verdict:** {READY/CONDITIONAL/NOT_READY/REVIEW_PENDING}
+
+{READY → "Run `ship` to implement."
+| CONDITIONAL → "Warnings exist. Proceed anyway?"
+| NOT_READY → "Fix issues, then re-check."
+| REVIEW_PENDING → "Standard tier — review spec before ship. Use [?][!][+][-][~][ok] notation, or say 'proceed'."}
+```

--- a/workflow/references/templates/review-output.md
+++ b/workflow/references/templates/review-output.md
@@ -1,0 +1,84 @@
+# Review Output Template
+
+Edit this file to customize what the agent returns after `review`. Decision logic: [actions/review.md](../actions/review.md).
+
+---
+
+## Per-File Findings
+
+For each file with findings, list issues with location:
+
+```
+{file_path}:{line} — {FAIL|WARN} [{perspective}] {one-line description}
+  Fix: {concrete action to take}
+```
+
+Rules:
+- One line per issue — description + fix on next line
+- Always include file path and line number
+- Always include a concrete fix (not just "consider improving")
+- FAIL = must fix. WARN = should fix. No other levels.
+- Skip PASS items — only show what needs action
+- Group by file, not by perspective
+
+---
+
+## Review Summary
+
+After all per-file findings:
+
+```markdown
+## Review: {N} files checked
+
+**FAIL ({N})** — must fix before shipping:
+1. `{file}:{line}` — [{perspective}] {description}
+2. `{file}:{line}` — [{perspective}] {description}
+
+**WARN ({N})** — should fix:
+1. `{file}:{line}` — [{perspective}] {description} (severity)
+2. `{file}:{line}` — [{perspective}] {description} (severity)
+
+**Verdict:** {CLEAN / HAS_BLOCKERS / WARNINGS_ONLY}
+```
+
+---
+
+## Output Rules
+
+- **Actionable only** — every finding has a Fix line. No vague "could be improved".
+- **File:line always** — user must be able to jump to the exact location.
+- **No noise** — skip PASS items entirely. Only show what needs action.
+- **Flat list** — no nested sections per perspective. One flat list sorted by severity (FAIL first, then WARN).
+- **Concrete fixes** — "Add `await` before `db.save()`" not "Consider handling async properly".
+- **Short** — one line per issue. Description ≤ 80 chars. Fix ≤ 80 chars.
+- **Verdict at the end** — CLEAN (0 FAIL, 0 WARN), WARNINGS_ONLY (0 FAIL, N WARN), HAS_BLOCKERS (N FAIL).
+
+---
+
+## Example
+
+```
+## Review: 3 files checked
+
+src/middleware/auth.ts:42 — FAIL [Security] JWT secret read from env without fallback
+  Fix: Add validation: `if (!secret) throw new Error("JWT_SECRET required")`
+
+src/routes/users.ts:18 — FAIL [Correctness] Missing await on async db.save()
+  Fix: Add `await` before `db.save(user)`
+
+src/routes/users.ts:31 — WARN [Performance] N+1 query in user list (medium)
+  Fix: Replace loop with `db.users.findMany({ where: { id: { in: ids } } })`
+
+src/utils/format.ts:7 — WARN [DX] Function name `fn` is not descriptive (low)
+  Fix: Rename to `formatUserDisplayName`
+
+**FAIL (2)** — must fix before shipping:
+1. `src/middleware/auth.ts:42` — [Security] JWT secret without fallback
+2. `src/routes/users.ts:18` — [Correctness] Missing await on db.save()
+
+**WARN (2)** — should fix:
+1. `src/routes/users.ts:31` — [Performance] N+1 query (medium)
+2. `src/utils/format.ts:7` — [DX] Non-descriptive function name (low)
+
+**Verdict:** HAS_BLOCKERS
+```

--- a/workflow/references/templates/ship-output.md
+++ b/workflow/references/templates/ship-output.md
@@ -1,0 +1,96 @@
+# Ship Output Template
+
+Edit this file to customize what the agent returns during and after `ship`. Decision logic: [actions/ship.md](../actions/ship.md).
+
+---
+
+## Iteration Output
+
+After each iteration:
+
+```markdown
+## Iteration {N}/{max}
+
+**Scope item:** {name} → {DONE / IN_PROGRESS / BLOCKED}
+**Quick pass:** lint {OK/FAIL} | typecheck {OK/FAIL}
+**Progress:** {completed}/{total} scope items ({percent}%)
+**ACs passing:** {N}/{total} Must Have | {N}/{total} Error
+
+{If review ran:}
+**Review:** {CLEAN / WARNINGS_ONLY / HAS_BLOCKERS} (see review output)
+
+**Next:** {what happens next iteration}
+```
+
+---
+
+## Exit Output
+
+### Clean
+
+```markdown
+## Ship Complete
+
+**Status:** CLEAN — all checks passing
+**Progress:** {N}/{N} scope items | {N}/{N} Must Have ACs | {N}/{N} Error ACs
+**Quality:** lint OK | typecheck OK | build OK | test OK
+**Review:** {CLEAN / WARNINGS_ONLY}
+
+Next: Run `done` to validate, retro, and archive.
+```
+
+### Partial
+
+```markdown
+## Ship Partial
+
+**Status:** PARTIAL — scope done, ACs failing
+**Progress:** {N}/{N} scope items | {passing}/{total} Must Have ACs | {passing}/{total} Error ACs
+**Failing ACs:**
+- AC-{N}: {description} — {why failing}
+
+Fix failing ACs, then re-run `ship`.
+```
+
+### Stuck
+
+```markdown
+## Ship Paused
+
+**Status:** STUCK — {reason}
+**Progress:** {N}/{total} scope items ({percent}%) | Iteration {N}/{max}
+**Blocked on:** {what's blocking progress}
+
+Options: continue (different approach) | reduce scope | defer | drop
+```
+
+### Hard Stop
+
+```markdown
+## Ship Stopped
+
+**Status:** MAX_ITERATIONS — hit limit at {N}
+**Progress:** {N}/{total} scope items | {passing}/{total} ACs
+**Remaining:**
+- [ ] {incomplete scope item}
+
+Reduce scope or re-plan.
+```
+
+---
+
+## Spec Mutation Output
+
+When user requests mid-loop changes:
+
+```markdown
+## Spec Updated
+
+**Added:** {N} scope items, {N} ACs
+**Modified:** {list}
+**Removed:** {list}
+**Traceability:** {PASS / orphans found}
+**New progress:** {completed}/{new_total} scope items
+
+Resuming ship loop.
+```

--- a/workflow/references/templates/spike-output.md
+++ b/workflow/references/templates/spike-output.md
@@ -1,0 +1,24 @@
+# Spike Output Template
+
+Edit this file to customize what the agent returns after `spike`. Decision logic: [actions/spike.md](../actions/spike.md).
+
+---
+
+```markdown
+## Spike: {question}
+
+**Time box:** {X}h | **Actual:** {Y}h
+**Decision:** GO / NO-GO / NEEDS_MORE_INFO
+
+### Findings
+- {what we discovered}
+- {evidence for/against}
+
+### Decision Rationale
+{why GO or NO-GO, with evidence}
+
+### Next Step
+- GO → `plan {follow-up idea}`
+- NO-GO → {alternative approach or why we're stopping}
+- NEEDS_MORE_INFO → {what additional spike or info is needed}
+```

--- a/workflow/references/templates/status-output.md
+++ b/workflow/references/templates/status-output.md
@@ -1,0 +1,25 @@
+# Status Output Template
+
+Edit this file to customize what the agent returns for `workflow` / status check. Decision logic: inline in [SKILL.md](../../SKILL.md#status-action).
+
+---
+
+```markdown
+## Workflow Status
+
+**State:** {IDLE / SPEC_READY / IN_PROGRESS / READY_FOR_DONE / STUCK}
+
+{If active spec:}
+**Spec:** `specs/active/{filename}`
+**Progress:** {N}/{total} scope items ({percent}%)
+**Current:** {what's in progress or next up}
+
+{If uncommitted changes:}
+**Uncommitted:** {N} files changed
+
+{If tasks exist:}
+**Tasks:** {N} pending | {N} in_progress | {N} completed
+
+### Suggested Next Action
+{suggestion based on state — e.g. "Run `ship` to continue" or "Run `done` to validate and close"}
+```


### PR DESCRIPTION
## Summary
- Add workflow skill: spec-first, quality-gated, pattern-driven development workflow
- 7 commands: plan, spike, ship, review, done, drop, workflow status
- 24 files across 5 categories:
  - 6 action references (plan, spike, ship, review, done, drop)
  - 5 pattern references (implementation, planning, debugging, decisions, decomposition)
  - 7 output templates (one per command)
  - 4 shared references (spec-template, quality-gates, session-management, memory-update)
  - 2 top-level (SKILL.md router, README.md docs)
- Agent-agnostic: works with Claude Code, OpenCode, Windsurf, Cursor, Codex, Aider
- Update root README: skill count 5→6, add workflow entry + install commands