### PR TITLE
chore(workflow): tighten activation triggers

### DIFF
--- a/workflow/SKILL.md
+++ b/workflow/SKILL.md
@@ -3,15 +3,14 @@ name: workflow
 description: |
   High-velocity solo development workflow. Idea to production same-day.
   8 commands: plan, spike, ship, review, spec-review, done, drop, workflow.
-  Auto-activates on: "plan", "spec", "ship", "implement", "build", "make", "write", "change",
-  "refactor", "fix", "review", "check code", "review spec", "analyze spec", "challenge spec",
+  Auto-activates on: "plan", "spec", "ship", "spike",
+  "spec-review", "review spec", "analyze spec", "challenge spec",
   "done", "finish", "complete", "drop", "abandon",
-  "workflow", "what's next", "whats next", "next step", "what now",
-  "what's up", "whats up".
+  "workflow", "what's next", "whats next", "next step", "what now".
 license: MIT
 compatibility: "Agent-agnostic. Works with Claude Code, OpenCode, Windsurf, Cursor, Codex, Aider, or any agent supporting SKILL.md."
 metadata:
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Workflow


### PR DESCRIPTION
Tightened `workflow` auto-activation triggers to avoid collisions in multi-skill installs.

### What changed
- Removed overly-generic triggers (`build`, `fix`, `review`, `refactor`, `implement`, `write`, `change`, `what’s up`, etc.)
- Kept explicit workflow entrypoints (`plan`, `spec`, `ship`, `spike`, `spec-review`, `done`, `drop`, `workflow`, and status prompts like “what’s next”)
- Bumped skill metadata version: `1.0` → `1.1`

### Why
Generic triggers made the router unpredictable when other skills are installed (e.g. `analyze` for “review”, `git/github` around PR work). This keeps `workflow` portable and deterministic.

### Testing
- Manual: verified activation list only contains workflow-specific intents