### PR TITLE
feat(workflow): add focus action for codebase priority analysis

### DIFF
--- a/workflow/README.md
+++ b/workflow/README.md
@@ -21,6 +21,7 @@ npx skills add bntvllnt/agent-skills --skill workflow -g
 | `spike {question}` | Time-boxed exploration, produces go/no-go |
 | `ship` or `ship {idea}` | Implement with build/review/fix loop |
 | `review` | Multi-perspective code review (5-9 perspectives) |
+| `focus` | Scan codebase, prioritize tasks toward production readiness |
 | `done` | Validate, retro, archive, propose memory update |
 | `drop` | Abandon with learnings preserved |
 | `workflow` | Show current state, suggest next action |
@@ -28,6 +29,29 @@ npx skills add bntvllnt/agent-skills --skill workflow -g
 No flags needed — the agent auto-detects intent from your natural language (e.g., "review the spec", "skip tests", "emergency fix", "production ready").
 
 ## Quickstart
+
+Don't know what to work on? Start with focus:
+
+```
+You:   focus
+
+Agent: Scanning codebase against 9 review perspectives...
+       Goal: Production readiness
+
+       Perspective Summary:
+         Security:    2 gaps (HIGH)
+         Testability: 3 gaps (MEDIUM)
+         Reliability: 1 gap (MEDIUM)
+
+       Do First:
+         1. Add input validation to /api/auth endpoints (Security, ~30min)
+         2. Add error handling to database queries (Reliability, ~1h)
+
+       Quick Wins:
+         3. Add missing test for user creation flow (Testability, ~30min)
+
+       Select tasks → specs created in specs/backlog/
+```
 
 Here's what a real workflow looks like end-to-end:
 
@@ -204,6 +228,7 @@ Start here
 └────┬─────┘
      │ Want to understand a phase?
      │
+     ├── Focus:   references/actions/focus.md
      ├── Plan:    references/actions/plan.md
      ├── Spike:   references/actions/spike.md
      ├── Ship:    references/actions/ship.md
@@ -222,6 +247,7 @@ Start here
 
      │ Want to customize output?
      │
+     ├── Focus:   references/templates/focus-output.md
      ├── Plan:    references/templates/plan-output.md
      ├── Spike:   references/templates/spike-output.md
      ├── Ship:    references/templates/ship-output.md
@@ -238,6 +264,17 @@ Start here
 ```
  YOU                          WORKFLOW                         OUTPUT
 ──────                        ────────                         ──────
+
+ "focus"
+      │
+      ├───────────────────▶  Scan specs (active/backlog/dropped/shipped)
+                             Ask goal (production/MVP/infra/custom)
+                             Dispatch perspective agents
+                             Rank findings ──────────────────▶  prioritized tasks
+      │
+ Select tasks
+      │
+      ├───────────────────▶  Create specs ───────────────────▶  specs/backlog/
 
  "plan {idea}"
       │
@@ -279,21 +316,31 @@ Start here
 ### Lifecycle
 
 ```
-┌──────────┐  plan   ┌──────────┐ review? ┌───────────┐ ready? ┌───────────┐
-│   IDEA   │────────▶│  DRAFT   │────────▶│ REVIEWING │───────▶│ DEV_READY │
-└──────────┘         └──────────┘         └───────────┘        └─────┬─────┘
-                          ▲                    │                     │ ship
-                          │ revise [?][!]      │                     ▼
-                          └────────────────────┘               ┌───────────┐
-                                                               │IMPLEMENTING│
-┌──────────┐  done   ┌──────────┐  clean  ┌───────────┐       └─────┬─────┘
-│ SHIPPED  │◄────────│  READY   │◄────────│   SHIP    │◄────────────┘
-└──────────┘         └──────────┘         │   LOOP    │──── iterate
-      │                                   └─────┬─────┘
-      │              ┌──────────┐               │ stuck
-      │              │ DROPPED  │◄── drop ──────┘
-      ▼              └──────────┘
- specs/shipped/                   specs/dropped/
+┌──────────┐  focus  ┌──────────┐  plan   ┌──────────┐ review? ┌───────────┐
+│ UNFOCUSED│────────▶│   IDEA   │────────▶│  DRAFT   │────────▶│ REVIEWING │
+└──────────┘         └──────────┘         └──────────┘         └───────────┘
+      ▲                                        ▲                    │
+      │                                        │ revise [?][!]      │ ready?
+      │                                        └────────────────────┘
+      │                                                             │
+      │              ┌──────────┐                             ┌───────────┐
+      │              │IMPLEMENTING│◄───────────── ship ───────│ DEV_READY │
+      │              └─────┬─────┘                            └───────────┘
+      │                    │
+      │              ┌───────────┐
+      │              │   SHIP    │──── iterate
+      │              │   LOOP    │
+      │              └─────┬─────┘
+      │                    │ clean          │ stuck
+      │              ┌──────────┐    ┌──────────┐
+      │   done       │  READY   │    │ DROPPED  │
+      └──────────────│          │    └──────────┘
+                     └──────────┘     specs/dropped/
+                          │
+                     ┌──────────┐
+                     │ SHIPPED  │
+                     └──────────┘
+                      specs/shipped/
 ```
 
 ### Quality Gates
@@ -325,6 +372,7 @@ workflow/
 │   │   ├── plan.md ───────────── Spec requirements, dev-readiness gates, review rounds
 │   │   ├── ship.md ───────────── Quality gates, iteration limits, exit criteria
 │   │   ├── review.md ─────────── Perspectives (add/remove/change levels)
+│   │   ├── focus.md ──────────── Codebase scan, perspective weights, ranking formula
 │   │   ├── done.md ───────────── Validation checklist, memory update settings
 │   │   └── drop.md ───────────── Drop flow
 │   │
@@ -333,6 +381,7 @@ workflow/
 │   │   ├── spike-output.md ───── Decision, findings, next step
 │   │   ├── ship-output.md ────── Iteration progress, exit states, spec mutations
 │   │   ├── review-output.md ──── Per-file findings, fix actions, verdict
+│   │   ├── focus-output.md ───── Ranked tasks, perspective scores, readiness
 │   │   ├── done-output.md ────── Validation results, retro, memory updates
 │   │   ├── drop-output.md ────── Drop reason, learnings, reusable pieces
 │   │   └── status-output.md ──── Current state, progress, suggested next action

--- a/workflow/SKILL.md
+++ b/workflow/SKILL.md
@@ -2,9 +2,10 @@
 name: workflow
 description: |
   High-velocity solo development workflow. Idea to production same-day.
-  8 commands: plan, spike, ship, review, spec-review, done, drop, workflow.
+  9 commands: plan, spike, ship, review, spec-review, focus, done, drop, workflow.
   Auto-activates on: "plan", "spec", "ship", "spike",
   "spec-review", "review spec", "analyze spec", "challenge spec",
+  "focus", "what should i do", "prioritize", "overwhelmed", "what should i work on",
   "done", "finish", "complete", "drop", "abandon",
   "workflow", "what's next", "whats next", "next step", "what now".
 license: MIT
@@ -39,6 +40,7 @@ High-velocity solo development. Idea to production same-day.
 | `ship` / `ship {idea}` | Implement + validate | [ship.md](references/actions/ship.md) |
 | `review` | Multi-perspective code review | [review.md](references/actions/review.md) |
 | `spec-review` | Adversarial spec analysis | [spec-review.md](references/actions/spec-review.md) |
+| `focus` | Priority analysis + task proposals | [focus.md](references/actions/focus.md) |
 | `done` | Validate + retro + archive | [done.md](references/actions/done.md) |
 | `drop` | Abandon, preserve learnings | [drop.md](references/actions/drop.md) |
 | `workflow` | Show state + suggest next | [Status](#status-action) (below) |
@@ -52,10 +54,11 @@ No flags needed. The agent auto-detects intent from context:
 ## Flow
 
 ```
-plan {idea} → ship → [implement/review/fix loop] → done
+focus → plan {idea} → ship → [implement/review/fix loop] → done
 ```
 
 Quick mode (<2h): `ship {idea} → done`
+Don't know what to work on: `focus`
 
 ## Philosophy
 
@@ -86,6 +89,8 @@ User input
   ├─ "review", "check code"              → Load references/actions/review.md
   ├─ "review spec", "analyze spec",
   │  "challenge spec"                    → Load references/actions/spec-review.md
+  ├─ "focus", "what should i do",
+  │  "prioritize", "overwhelmed"         → Load references/actions/focus.md
   ├─ "done", "finish", "complete"        → Load references/actions/done.md
   ├─ "drop", "abandon"                   → Load references/actions/drop.md
   └─ "workflow", "what's next", "what now",
@@ -118,6 +123,7 @@ Output: Follow [status-output.md](references/templates/status-output.md).
 ```
 specs/
   active/       ← Current work (0-1 specs)
+  backlog/      ← Queued work from focus
   shipped/      ← Completed features
   dropped/      ← Abandoned with learnings
   history.log   ← One-line per feature shipped/dropped
@@ -138,10 +144,10 @@ All behavior is configurable by editing the skill files directly.
 ## References
 
 Actions:
-- [Plan](references/actions/plan.md) | [Ship](references/actions/ship.md) | [Review](references/actions/review.md) | [Spec Review](references/actions/spec-review.md) | [Done](references/actions/done.md) | [Drop](references/actions/drop.md) | [Spike](references/actions/spike.md)
+- [Plan](references/actions/plan.md) | [Ship](references/actions/ship.md) | [Review](references/actions/review.md) | [Spec Review](references/actions/spec-review.md) | [Focus](references/actions/focus.md) | [Done](references/actions/done.md) | [Drop](references/actions/drop.md) | [Spike](references/actions/spike.md)
 
 Output templates:
-- [Plan + Spec Review](references/templates/plan-output.md) | [Ship](references/templates/ship-output.md) | [Review](references/templates/review-output.md) | [Done](references/templates/done-output.md) | [Drop](references/templates/drop-output.md) | [Spike](references/templates/spike-output.md) | [Status](references/templates/status-output.md)
+- [Plan + Spec Review](references/templates/plan-output.md) | [Ship](references/templates/ship-output.md) | [Review](references/templates/review-output.md) | [Focus](references/templates/focus-output.md) | [Done](references/templates/done-output.md) | [Drop](references/templates/drop-output.md) | [Spike](references/templates/spike-output.md) | [Status](references/templates/status-output.md)
 
 Review standards:
 - [Production Standards](references/reviews/production-standards.md)

--- a/workflow/references/actions/focus.md
+++ b/workflow/references/actions/focus.md
@@ -1,0 +1,277 @@
+# Focus Action
+
+> **Agent:** Load this file when `focus` triggers. Also load `references/reviews/production-standards.md` — it provides extended checklists for scanning.
+
+Scan codebase against review perspectives, surface prioritized tasks toward production readiness. Output: ranked task proposals, user selects, specs created in `specs/backlog/`.
+
+---
+
+## Task Tracking (MANDATORY)
+
+Before starting, create tasks in your agent's built-in task/todo system:
+
+```
+[ ] Detect project (Step 0)
+[ ] Scan existing specs (Step 1)
+[ ] Ask goal (Step 2)
+[ ] Dispatch perspective agents (Step 3)
+[ ] Synthesize findings (Step 4)
+[ ] Rank and present (Steps 5-6)
+[ ] User selects → create specs (Step 7)
+```
+
+---
+
+## Step 0: Detect Project
+
+Reuse from plan.md:
+
+```
+Check project for:
+  - Monorepo (turbo.json)
+  - Package manager (pnpm/yarn/bun/npm from lockfile)
+  - Test runner (vitest/jest/pytest from config)
+  - Framework (next/expo/convex from package.json)
+  - Primary language (from file extensions, tsconfig, pyproject.toml)
+```
+
+Also estimate codebase size:
+
+| Size | Files | Agent Count |
+|------|-------|-------------|
+| Small | <50 source files | 2-3 agents |
+| Medium | 50-200 source files | 3-4 agents |
+| Large | 200+ source files | 4-5 agents |
+
+Count source files only (exclude `node_modules`, `dist`, `.git`, lockfiles, generated).
+
+---
+
+## Step 1: Scan Existing Specs
+
+Scan all `specs/` subfolders for existing work:
+
+```
+specs/active/    → Tag: [ACTIVE] — current work, show prominently
+specs/backlog/   → Tag: [BACKLOG] — queued work, check for overlap with new findings
+specs/dropped/   → Tag: [DROPPED] — abandoned, note learnings
+specs/shipped/   → Tag: [SHIPPED] — last 10 by modification date only, context only
+```
+
+For each spec found, extract:
+- Title, status, estimated effort
+- Key scope items (what it covers)
+
+**Rules:**
+- If active spec exists, show it first — user may want to finish it before new work
+- Dropped specs with relevant learnings: note what was learned, don't re-propose same approach
+- Shipped specs: context only, never re-proposed
+- Backlog specs that overlap with new findings: tag as `[BACKLOG]`, link to spec, skip duplicate proposal
+
+---
+
+## Step 2: Ask Goal
+
+Use interactive question (AskUserQuestion or equivalent):
+
+```
+What should we focus on?
+
+1. Production readiness — Harden: tests, security, error handling, monitoring
+2. MVP / ship value — Quickest path to user-visible value: TODOs, incomplete features, UX gaps
+3. Infrastructure — Scale foundation: patterns, deps, type safety, duplication
+4. Other — Custom focus (describe)
+```
+
+**Production readiness is ALWAYS the underlying lens.** Goal selection changes weighting, not the baseline. Every scan checks production bar as minimum.
+
+---
+
+## Step 3: Dispatch Perspective Agents
+
+Dispatch parallel Explore agents. Each agent scans the codebase against assigned perspectives using checklists from `references/reviews/production-standards.md`.
+
+**This is NOT a diff review — agents scan the WHOLE codebase against perspective checklists.**
+
+### Agent Assignment by Goal
+
+| Goal | Primary Perspectives (weighted high) | Secondary (still checked) |
+|------|--------------------------------------|--------------------------|
+| Production | Security, Reliability, Observability, Testability | Correctness, Performance, DX, Scalability |
+| MVP | Correctness, DX, Performance | Security, Reliability, Testability |
+| Infra | Scalability, DX, Testability | Performance, Reliability, Security |
+| Custom | Agent picks based on user description | Production baseline always |
+
+### Agent Distribution
+
+Distribute 9 perspectives across agents (2-3 perspectives per agent):
+
+```
+Small codebase (2-3 agents):
+  Agent 1: Security, Reliability, Observability
+  Agent 2: Correctness, Performance, DX
+  Agent 3 (if needed): Scalability, Testability, Accessibility
+
+Medium codebase (3-4 agents):
+  Agent 1: Security, Reliability
+  Agent 2: Correctness, Performance
+  Agent 3: DX, Scalability
+  Agent 4 (if needed): Observability, Testability, Accessibility
+
+Large codebase (4-5 agents):
+  Agent 1: Security, Reliability
+  Agent 2: Correctness, Performance
+  Agent 3: DX, Testability
+  Agent 4: Scalability, Observability
+  Agent 5 (if needed): Accessibility + overflow
+```
+
+Skip Accessibility unless UI components detected in codebase.
+
+### Agent Prompt Template
+
+Each agent receives:
+
+```
+Scan this codebase against the following review perspectives.
+You are scanning the WHOLE codebase, not reviewing a diff.
+
+Perspectives assigned: {perspective names}
+
+For each perspective, use this checklist:
+{paste extended checklist items from production-standards.md for assigned perspectives}
+
+Instructions:
+1. Use Glob to find relevant source files (skip node_modules, dist, .git, generated)
+2. Use Grep to search for patterns related to checklist items
+3. Use Read to examine files with potential issues
+4. For each finding, propose a CONCRETE TASK (not an observation):
+   - BAD: "Missing error handling detected"
+   - GOOD: "Add error handling to database queries in src/db/users.ts"
+5. Score each task:
+   - Impact: H (affects users/security/data) / M (affects DX/maintainability) / L (cosmetic/minor)
+   - Effort: L (<1h) / M (1-4h) / H (4h+)
+   - Risk-if-ignored: H (will cause incidents) / M (will slow team) / L (annoyance)
+6. Include file evidence: path:line for each finding
+7. Focus on {primary perspectives} — these are weighted highest for the "{goal}" goal
+
+Output format per task:
+  Task: {actionable task description}
+  Perspective: {which perspective flagged this}
+  Impact: H/M/L
+  Effort: L/M/H
+  Risk: H/M/L
+  Evidence: {file:line — brief description}
+```
+
+### Sampling Strategy (Large Codebases)
+
+For 500+ source files, agents should focus on:
+1. Files changed in last 30 days (recent activity = higher relevance)
+2. Entry points (main files, route handlers, API endpoints)
+3. Critical paths (auth, payments, data mutations)
+4. Files with TODOs/FIXMEs/HACKs
+5. Files without test coverage (look for missing `*.test.*` counterparts)
+
+---
+
+## Step 4: Synthesize
+
+Collect results from all agents. Process:
+
+1. **Deduplicate:** Merge tasks pointing at same file/issue from different perspectives
+2. **Cross-reference with existing specs:** If a finding overlaps with a backlog/active spec, tag it `[BACKLOG]`/`[ACTIVE]` instead of proposing as new
+3. **Merge related tasks:** Group small tasks into logical units (e.g., "Add error handling to 3 DB query files" → one task)
+4. **Validate evidence:** Ensure file:line references are real (agents may hallucinate)
+
+---
+
+## Step 5: Rank
+
+### Scoring Formula
+
+```
+score = (w_impact * impact) + (w_effort * (4 - effort)) + (w_risk * risk)
+```
+
+Where impact/effort/risk are: H=3, M=2, L=1
+
+### Goal Weights
+
+| Goal | w_impact | w_effort | w_risk |
+|------|----------|----------|--------|
+| Production | 3 | 1 | 5 |
+| MVP | 5 | 3 | 1 |
+| Infra | 2 | 2 | 2 |
+| Custom | 3 | 2 | 3 |
+
+### Tier Assignment
+
+Sort by score descending, then group:
+
+| Tier | Criteria | Description |
+|------|----------|-------------|
+| Do First | High impact + Low effort | Maximum value, minimum cost |
+| Plan Next | High impact + Medium/High effort | Needs spec, worth the investment |
+| Quick Wins | Medium impact + Low effort | Easy improvements, good momentum |
+
+Cap at 10-15 tasks total. If more found, keep highest-scored.
+
+---
+
+## Step 6: Present
+
+Output per `references/templates/focus-output.md`.
+
+Include:
+- Perspective summary (gaps per perspective)
+- Existing specs (if any found in Step 1)
+- Ranked task tables by tier
+- Production readiness score (quick health check per perspective)
+- Effort estimates use same calibration as plan.md: aggressive, AI-assisted
+
+---
+
+## Step 7: User Selects
+
+Use interactive multi-select (AskUserQuestion multiSelect or equivalent):
+
+```
+Select tasks to plan (select multiple):
+  1. {task description} (Effort: {est}, Perspective: {name})
+  2. ...
+```
+
+For each selected task:
+
+1. Invoke `plan` action with the task as the idea
+2. Spec created in `specs/backlog/` (NOT `specs/active/`)
+3. User manually moves to `specs/active/` when ready to `ship`
+
+If user selects a task that overlaps with existing backlog spec, note it instead of creating duplicate.
+
+---
+
+## Edge Cases
+
+| Case | Handle |
+|------|--------|
+| Empty codebase (no source files) | "No code to analyze. Run `plan {idea}` to start." |
+| No findings | "Production-ready baseline met. Run `plan {idea}` for new features." |
+| All tasks >4h effort | Flag: "Large scope tasks — will split during plan phase." |
+| Existing spec covers finding | Tag `[BACKLOG]`/`[DROPPED]`, link to spec, skip duplicate |
+| Active spec exists | Show prominently: "Active work in progress — finish first?" |
+| Many shipped specs (>10) | Only load last 10 by modification date |
+| No test runner detected | Note in testability perspective: "No test infrastructure — propose setup as task" |
+
+---
+
+## Lifecycle Position
+
+```
+focus → plan → ship → done → focus (repeat)
+  │                              ▲
+  └──────────────────────────────┘
+```
+
+Focus is the entry point when you don't know what to work on next. It completes the cycle by feeding back into `plan`.

--- a/workflow/references/templates/focus-output.md
+++ b/workflow/references/templates/focus-output.md
@@ -1,0 +1,94 @@
+# Focus Output Template
+
+> **Agent:** Use this template for all focus action output. Fill sections based on scan results.
+
+---
+
+## Template
+
+```markdown
+## Focus: {Goal}
+
+**Baseline:** Production readiness | **Goal lens:** {selected goal}
+**Scanned:** {N} files | **Perspectives:** {N} active | **Date:** {YYYY-MM-DD}
+
+### Perspective Summary
+
+| Perspective | Gaps Found | Severity | Top Issue |
+|-------------|-----------|----------|-----------|
+| {name} | {count} | {HIGH/MEDIUM/LOW} | {one-line description} |
+
+{if existing specs found:}
+
+### Existing Specs
+
+| Spec | Status | Est | Relevance to Goal |
+|------|--------|-----|-------------------|
+| {spec title} | [ACTIVE] / [BACKLOG] / [DROPPED] | {time} | {how it relates} |
+
+{if active spec:}
+> **Active work:** {spec title} — consider finishing this first.
+
+### Proposed Tasks
+
+#### Do First (High Impact, Low Effort)
+
+| # | Task | Perspective | Impact | Effort | Est | Key Files |
+|---|------|-------------|--------|--------|-----|-----------|
+| 1 | {actionable task} | {perspective} | H | L | {time} | `{file:line}` |
+
+#### Plan Next (High Impact, Medium+ Effort)
+
+| # | Task | Perspective | Impact | Effort | Est | Key Files |
+|---|------|-------------|--------|--------|-----|-----------|
+| 1 | {actionable task} | {perspective} | H | M/H | {time} | `{file:line}` |
+
+#### Quick Wins
+
+| # | Task | Perspective | Impact | Effort | Est | Key Files |
+|---|------|-------------|--------|--------|-----|-----------|
+| 1 | {actionable task} | {perspective} | M | L | {time} | `{file:line}` |
+
+### Production Readiness Score
+
+| Perspective | Score | Gaps |
+|-------------|-------|------|
+| Correctness | {GOOD/FAIR/POOR} | {brief gap summary or "—"} |
+| Security | {GOOD/FAIR/POOR} | {brief gap summary or "—"} |
+| Reliability | {GOOD/FAIR/POOR} | {brief gap summary or "—"} |
+| Performance | {GOOD/FAIR/POOR} | {brief gap summary or "—"} |
+| DX | {GOOD/FAIR/POOR} | {brief gap summary or "—"} |
+| Scalability | {GOOD/FAIR/POOR} | {brief gap summary or "—"} |
+| Observability | {GOOD/FAIR/POOR} | {brief gap summary or "—"} |
+| Testability | {GOOD/FAIR/POOR} | {brief gap summary or "—"} |
+| Accessibility | {GOOD/FAIR/POOR/N/A} | {brief gap summary or "—"} |
+
+**Overall:** {GOOD/FAIR/POOR} — {one-line summary}
+
+### Next
+
+Select tasks above → specs created in `specs/backlog/` → move to `specs/active/` when ready → `ship`
+```
+
+---
+
+## Scoring Guide
+
+| Score | Meaning |
+|-------|---------|
+| GOOD | No high-severity gaps, minor improvements only |
+| FAIR | Some gaps, none critical, addressable in 1-2 tasks |
+| POOR | Significant gaps, needs dedicated work before production |
+| N/A | Perspective not applicable (e.g., Accessibility for CLI tools) |
+
+---
+
+## Rules
+
+- **Tasks not findings:** Every row is an actionable task, not a passive observation
+- **Evidence required:** Every task links to at least one `file:line`
+- **Effort estimates:** Use aggressive AI-assisted estimates (manual 10h = AI 1-2h)
+- **Max tasks:** 10-15 total across all tiers. Trim lowest-scored if more
+- **Empty tiers:** Omit tier section entirely if no tasks in that tier
+- **Existing specs:** Only show section if specs were found
+- **Active spec warning:** Always show if active spec exists


### PR DESCRIPTION
## Summary

- Add `focus` command that scans the entire codebase against the existing 9 review perspectives (Security, Reliability, Correctness, Performance, DX, Scalability, Observability, Testability, Accessibility) and surfaces prioritized tasks toward production readiness
- Reuses `production-standards.md` extended checklists as the scanning framework — no new analysis system
- Goal-weighted ranking (production=risk-driven, MVP=value-driven, infra=balanced) with tiered output: Do First / Plan Next / Quick Wins
- Selected tasks flow into `plan` → specs created in `specs/backlog/`

New files:
- `workflow/references/actions/focus.md` — 7-step protocol (detect project, scan specs, ask goal, dispatch perspective agents, synthesize, rank, user selects)
- `workflow/references/templates/focus-output.md` — output template with perspective summary, tiered task tables, production readiness score

Updated:
- `workflow/SKILL.md` — 9 commands, triggers, router, `specs/backlog/` in structure, references
- `workflow/README.md` — commands table, quickstart example, lifecycle diagram, reading order, customization tree

## Test plan

- [ ] Trigger with "focus" / "what should I do" / "prioritize" / "overwhelmed" → loads focus.md
- [ ] AskUserQuestion presents 3 goal options + Other
- [ ] Agents dispatch in parallel using review perspective checklists
- [ ] Output matches focus-output.md template with ranked tasks + production readiness score
- [ ] User multi-select → plan creates specs in `specs/backlog/`
- [ ] No regression: `workflow` status, `review`, `plan`, `ship`, `done` all still work