### PR TITLE
feat(workflow): add PREVENT step to bug fix anti-cascade protocol

### DIFF
--- a/workflow/references/actions/ship.md
+++ b/workflow/references/actions/ship.md
@@ -38,6 +38,7 @@ Before starting any implementation, create tasks in your agent's built-in task/t
 [ ] GREEN: implement fix, verify test passes
 [ ] DIFF: run full suite, compare to baseline (zero new failures)
 [ ] SCAN: check codebase for sibling bugs
+[ ] PREVENT: propose prevention rules (max 2, non-trivial bugs only)
 ```
 
 Update tasks as you work: mark in-progress when starting, complete when done. One task in-progress at a time.
@@ -92,9 +93,12 @@ All bug fixes follow this protocol. Full details: [regression-testing.md](../pat
 4. DIFF     → Run full test suite again, compare to baseline
 5. BLOCK    → Any NEW failures = fix introduced regressions → roll back, rethink
 6. SCAN     → Check codebase for sibling bugs (same pattern)
+7. PREVENT  → Propose rules to prevent this class of bug (max 2)
 ```
 
 **DIFF is the anti-cascade mechanism.** By comparing full suite results before and after, you catch any regression the fix introduces — before it cascades.
+
+**PREVENT is lightweight:** max 2 proposals, inline approval, advisory (not blocking). Covers coding rules, anti-patterns, quality checks only. Skip for trivial bugs and emergencies. Full details: [regression-testing.md](../patterns/regression-testing.md) Step 7.
 
 If fix introduces regressions (DIFF fails):
 - Option A: Fix regressions without breaking the original fix

--- a/workflow/references/memory-update.md
+++ b/workflow/references/memory-update.md
@@ -48,7 +48,7 @@ From the retro and session history, identify learnings in 6 categories:
 | **Process rules** | Workflow improvements from the session | "Run integration tests before unit tests in this project" |
 | **Patterns & Anti-patterns** | User preferences, repeated requests, mistakes, failed approaches, regressions | "User always wants error boundaries around async components" |
 
-**Note on bug fixes:** Bug fixes trigger lightweight PREVENT proposals inline during `ship` (max 2, coding rules/anti-patterns/quality checks only). See [regression-testing.md](patterns/regression-testing.md) Step 7. The `done` memory update handles session-wide learnings across all categories. When extracting learnings here, **skip proposals already saved during PREVENT** to avoid duplicates.
+**Note on bug fixes:** Bug fixes trigger lightweight PREVENT proposals inline during `ship` (max 2, coding rules/anti-patterns/quality checks only). See regression-testing.md Step 7. PREVENT uses the same agent-detection and file-targeting logic from Step 3 (Classify & Target) above. The `done` memory update handles session-wide learnings across all categories. When extracting learnings here, **skip proposals already saved during PREVENT** to avoid duplicates.
 
 **Patterns** capture what to remember so the agent improves across sessions:
 - **User preferences**: coding style requests, architecture preferences, naming conventions the user enforces ("user prefers explicit return types on all functions")

--- a/workflow/references/memory-update.md
+++ b/workflow/references/memory-update.md
@@ -48,6 +48,8 @@ From the retro and session history, identify learnings in 6 categories:
 | **Process rules** | Workflow improvements from the session | "Run integration tests before unit tests in this project" |
 | **Patterns & Anti-patterns** | User preferences, repeated requests, mistakes, failed approaches, regressions | "User always wants error boundaries around async components" |
 
+**Note on bug fixes:** Bug fixes trigger lightweight PREVENT proposals inline during `ship` (max 2, coding rules/anti-patterns/quality checks only). See [regression-testing.md](patterns/regression-testing.md) Step 7. The `done` memory update handles session-wide learnings across all categories. When extracting learnings here, **skip proposals already saved during PREVENT** to avoid duplicates.
+
 **Patterns** capture what to remember so the agent improves across sessions:
 - **User preferences**: coding style requests, architecture preferences, naming conventions the user enforces ("user prefers explicit return types on all functions")
 - **Repeated requests**: things the user asks for repeatedly that should be default behavior ("always add loading states to async UI")

--- a/workflow/references/patterns/regression-testing.md
+++ b/workflow/references/patterns/regression-testing.md
@@ -15,6 +15,7 @@ Core problem: fix A → breaks B → fix B → breaks C. This protocol breaks th
 4. DIFF      → Run full test suite again, compare to baseline
 5. BLOCK     → Any NEW failures = regressions → roll back, rethink
 6. SCAN      → Check codebase for sibling bugs (same pattern)
+7. PREVENT   → Propose rules to prevent this class of bug (max 2)
 ```
 
 ### Step-by-Step
@@ -92,6 +93,48 @@ If siblings found → propose batch fix to user:
 Do NOT auto-fix siblings. Propose only.
 ```
 
+**7. PREVENT** — Propose rules to prevent this class of bug.
+
+**When to run:** After SCAN, for non-trivial bugs with a generalizable root cause.
+
+**When to skip:**
+- Trivial bugs (typos, config one-liners, obvious mistakes)
+- Existing rule already covers this class of error
+- Emergency/hotfix (speed > prevention)
+
+```
+Protocol:
+
+1. CLASSIFY root cause → map to prevention category (see table below)
+2. GENERATE max 2 proposals → concise, actionable rules
+3. CHECK existing rules → read user/project rules, skip if covered
+4. PROPOSE inline → user approves/declines immediately
+
+Output format per proposal:
+  [{target file} § {section}] {type}: "{rule text}"
+  _Prevents: {class of error}_
+```
+
+**Root cause → prevention category:**
+
+| Root Cause | Prevention Category | Example Rule |
+|-----------|-------------------|-------------|
+| Missing null/undefined check | Coding rule | "Always null-check optional fields before access" |
+| Wrong type assumption | Coding rule | "Use discriminated unions for API responses, never assume shape" |
+| Missing validation at boundary | Quality check | "Validate all external input at API boundaries with Zod" |
+| Incorrect error handling | Anti-pattern | "Never swallow errors in catch blocks — rethrow or log with context" |
+| Race condition / shared state | Coding rule | "Wrap shared state mutations in transactions or locks" |
+| Missing edge case | Quality check | "Test empty/null/boundary inputs for all public functions" |
+| Wrong API usage | Anti-pattern | "Never call {API} without {required precondition}" |
+| Config/env assumption | Quality check | "Validate required env vars at startup, fail fast if missing" |
+
+**Proposal rules:**
+- Max 2 proposals per fix — keeps it lightweight
+- Categories: coding rules, anti-patterns, quality checks only (no process/thinking patterns)
+- Advisory, not blocking — user can decline with no gate failure
+- Uses same targeting logic as memory-update.md (project CLAUDE.md, user rules, AGENTS.md)
+- Never auto-apply — always propose, user approves
+
 ## Bug Type → Test Pattern Matrix
 
 | Bug Type | Test Pattern | What to Assert |
@@ -160,3 +203,7 @@ AC-B2 + AC-B3 = TDD proof. AC-B4 = anti-cascade proof.
 - NEVER skip SCAN for non-emergency fixes
 - NEVER auto-fix sibling bugs without user approval
 - NEVER treat flaky tests as "acceptable" — flag them
+- NEVER propose more than 2 prevention rules per fix
+- NEVER auto-apply prevention rules — always propose, user approves
+- NEVER propose vague rules ("be more careful") — must be specific and actionable
+- NEVER duplicate existing rules — check before proposing

--- a/workflow/references/templates/ship-output.md
+++ b/workflow/references/templates/ship-output.md
@@ -18,6 +18,8 @@ After each iteration:
 
 {If review ran:}
 **Review:** {CLEAN / WARNINGS_ONLY / HAS_BLOCKERS} (see review output)
+{If bug fix + PREVENT ran:}
+**PREVENT:** {N} rules proposed | {approved/declined/skipped}
 
 **Next:** {what happens next iteration}
 ```
@@ -35,6 +37,8 @@ After each iteration:
 **Progress:** {N}/{N} scope items | {N}/{N} Must Have ACs | {N}/{N} Error ACs
 **Quality:** lint OK | typecheck OK | build OK | test OK
 **Review:** {CLEAN / WARNINGS_ONLY}
+{If bug fix:}
+**Prevention:** {N} rules saved to {files} | {N} declined
 
 Next: Run `done` to validate, retro, and archive.
 ```
@@ -93,4 +97,28 @@ When user requests mid-loop changes:
 **New progress:** {completed}/{new_total} scope items
 
 Resuming ship loop.
+```
+
+---
+
+## Bug Fix Iteration Example
+
+```markdown
+## Iteration 1/1 (Bug Mode)
+
+**Bug:** Null reference on user.email when profile incomplete
+**BASELINE:** 42 pass | 0 fail | 2 skipped
+**RED:** test_null_email_profile → FAIL (confirmed bug)
+**GREEN:** Added null check in getDisplayName() → test PASSES
+**DIFF:** 43 pass | 0 fail | 2 skipped (zero new failures)
+**SCAN:** Found 2 sibling locations with same pattern → proposed batch fix
+**PREVENT:** 2 rules proposed
+
+  1. [P/CLAUDE.md § Coding Rules] rule: "Always null-check optional user fields (email, phone, avatar) before access"
+     _Prevents: null reference errors on incomplete user profiles_
+
+  2. [~/.claude/rules/coding.md § Anti-Patterns] anti-pattern: "Never assume user profile fields are populated — use optional chaining or explicit guards"
+     _Prevents: runtime crashes from missing optional fields_
+
+  Apply which? [all / 1,2 / none]
 ```

--- a/workflow/references/templates/ship-output.md
+++ b/workflow/references/templates/ship-output.md
@@ -114,10 +114,10 @@ Resuming ship loop.
 **SCAN:** Found 2 sibling locations with same pattern → proposed batch fix
 **PREVENT:** 2 rules proposed
 
-  1. [P/CLAUDE.md § Coding Rules] rule: "Always null-check optional user fields (email, phone, avatar) before access"
+  1. [{project config} § Coding Rules] rule: "Always null-check optional user fields (email, phone, avatar) before access"
      _Prevents: null reference errors on incomplete user profiles_
 
-  2. [~/.claude/rules/coding.md § Anti-Patterns] anti-pattern: "Never assume user profile fields are populated — use optional chaining or explicit guards"
+  2. [{user config} § Anti-Patterns] anti-pattern: "Never assume user profile fields are populated — use optional chaining or explicit guards"
      _Prevents: runtime crashes from missing optional fields_
 
   Apply which? [all / 1,2 / none]


### PR DESCRIPTION
## Summary

- Adds **Step 7: PREVENT** to anti-cascade TDD protocol (after SCAN)
- After fixing a non-trivial bug, classifies root cause and proposes max 2 prevention rules inline during `ship`
- Advisory, not blocking — user approves/declines immediately
- Deduplicates with `done` memory update (skips already-saved proposals)

## Files changed

| File | Change |
|------|--------|
| `regression-testing.md` | Full Step 7 section: when to run/skip, root cause classification table, proposal format, anti-patterns |
| `ship.md` | Bug mode task list + protocol header updated to 7 steps + PREVENT note |
| `ship-output.md` | Iteration/clean exit templates + bug fix example with PREVENT proposals |
| `memory-update.md` | Deduplication note after Step 2 (skip PREVENT proposals at `done`) |

## Design decisions

- **Step 7 of existing protocol** (not separate mechanism) — context is freshest right after fix
- **Max 2 proposals** — lightweight vs memory-update's 5
- **Coding rules + anti-patterns + quality checks only** — no process/thinking patterns
- **Same targeting logic** as memory-update.md (project CLAUDE.md, user rules, AGENTS.md)

## Test plan

- [ ] Read all 4 files end-to-end for consistency
- [ ] Verify cross-references: ship.md → regression-testing.md → memory-update.md
- [ ] Verify no contradictions with done.md Step 4 (memory update)
- [ ] Walk through example: "fix null reference bug" → trace through all 7 steps → verify output template matches