### PR TITLE
feat(workflow): extract fix action from ship for dedicated bug fixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Build and operate Convex backends with best practices, validation, and Convex MC
 
 ### [Workflow](./workflow/) - High-Velocity Solo Development
 
-Idea to production same-day. Spec-first, quality-gated development: plan, spike, ship, review, done, drop.
+Idea to production same-day. Spec-first, quality-gated development: plan, spike, ship, fix, review, done, drop.
 
 [View skill documentation →](./workflow/SKILL.md)
 

--- a/workflow/SKILL.md
+++ b/workflow/SKILL.md
@@ -2,8 +2,9 @@
 name: workflow
 description: |
   High-velocity solo development workflow. Idea to production same-day.
-  9 commands: plan, spike, ship, review, spec-review, focus, done, drop, workflow.
+  10 commands: plan, spike, ship, fix, review, spec-review, focus, done, drop, workflow.
   Auto-activates on: "plan", "spec", "ship", "spike",
+  "fix", "debug", "repair",
   "spec-review", "review spec", "analyze spec", "challenge spec",
   "focus", "what should i do", "prioritize", "overwhelmed", "what should i work on",
   "done", "finish", "complete", "drop", "abandon",
@@ -11,7 +12,7 @@ description: |
 license: MIT
 compatibility: "Agent-agnostic. Works with Claude Code, OpenCode, Windsurf, Cursor, Codex, Aider, or any agent supporting SKILL.md."
 metadata:
-  version: "1.1"
+  version: "1.2"
 ---
 
 # Workflow
@@ -38,6 +39,7 @@ High-velocity solo development. Idea to production same-day.
 | `plan {idea}` | Create spec | [plan.md](references/actions/plan.md) |
 | `spike {question}` | Time-boxed exploration | [spike.md](references/actions/spike.md) |
 | `ship` / `ship {idea}` | Implement + validate | [ship.md](references/actions/ship.md) |
+| `fix` / `fix {bug}` | Scientific debug + regression fix | [fix.md](references/actions/fix.md) |
 | `review` | Multi-perspective code review | [review.md](references/actions/review.md) |
 | `spec-review` | Adversarial spec analysis | [spec-review.md](references/actions/spec-review.md) |
 | `focus` | Priority analysis + task proposals | [focus.md](references/actions/focus.md) |
@@ -48,13 +50,15 @@ High-velocity solo development. Idea to production same-day.
 No flags needed. The agent auto-detects intent from context:
 - "review the spec" → manual review pause
 - "skip tests" → skip test gate (documented)
+- "fix this bug" → dedicated bug fix with regression test
 - "emergency fix" → bypass spec ceremony
 - "production ready" → production validation
 
 ## Flow
 
 ```
-focus → plan {idea} → ship → [implement/review/fix loop] → done
+Features: focus → plan {idea} → ship → [implement/review/fix loop] → done
+Bug fixes: fix {bug} → [investigate/TDD/validate] → done
 ```
 
 Quick mode (<2h): `ship {idea} → done`
@@ -91,7 +95,8 @@ User input
   │
   ├─ "plan", "spec", "design"           → Load references/actions/plan.md
   ├─ "spike", "explore", "investigate"   → Load references/actions/spike.md
-  ├─ "ship", "implement", "fix", "build" → Load references/actions/ship.md
+  ├─ "ship", "implement", "build"         → Load references/actions/ship.md
+  ├─ "fix", "debug", "repair"            → Load references/actions/fix.md
   ├─ "review", "check code"              → Load references/actions/review.md
   ├─ "review spec", "analyze spec",
   │  "challenge spec"                    → Load references/actions/spec-review.md
@@ -150,10 +155,10 @@ All behavior is configurable by editing the skill files directly.
 ## References
 
 Actions:
-- [Plan](references/actions/plan.md) | [Ship](references/actions/ship.md) | [Review](references/actions/review.md) | [Spec Review](references/actions/spec-review.md) | [Focus](references/actions/focus.md) | [Done](references/actions/done.md) | [Drop](references/actions/drop.md) | [Spike](references/actions/spike.md)
+- [Plan](references/actions/plan.md) | [Ship](references/actions/ship.md) | [Fix](references/actions/fix.md) | [Review](references/actions/review.md) | [Spec Review](references/actions/spec-review.md) | [Focus](references/actions/focus.md) | [Done](references/actions/done.md) | [Drop](references/actions/drop.md) | [Spike](references/actions/spike.md)
 
 Output templates:
-- [Plan + Spec Review](references/templates/plan-output.md) | [Ship](references/templates/ship-output.md) | [Review](references/templates/review-output.md) | [Focus](references/templates/focus-output.md) | [Done](references/templates/done-output.md) | [Drop](references/templates/drop-output.md) | [Spike](references/templates/spike-output.md) | [Status](references/templates/status-output.md)
+- [Plan + Spec Review](references/templates/plan-output.md) | [Ship](references/templates/ship-output.md) | [Fix](references/templates/fix-output.md) | [Review](references/templates/review-output.md) | [Focus](references/templates/focus-output.md) | [Done](references/templates/done-output.md) | [Drop](references/templates/drop-output.md) | [Spike](references/templates/spike-output.md) | [Status](references/templates/status-output.md)
 
 Review standards:
 - [Production Standards](references/reviews/production-standards.md)

--- a/workflow/references/actions/fix.md
+++ b/workflow/references/actions/fix.md
@@ -29,7 +29,7 @@ CLASSIFY → highly complex? → INVESTIGATE (parallel agents) → CONVERGE → 
 
 BASELINE → RED → GREEN → DIFF → BLOCK
   BLOCK [new failures] → ROLLBACK → rethink approach → BASELINE
-  BLOCK [no new failures] → SCAN → PREVENT → VALIDATE → DONE
+  BLOCK [no new failures] → SCAN → LEARN → VALIDATE → DONE
 ```
 
 **States:**
@@ -44,8 +44,8 @@ BASELINE → RED → GREEN → DIFF → BLOCK
 | GREEN | RED test exists | Fix implemented, regression test PASSES | DIFF |
 | DIFF | Fix passes regression test | Full suite re-run, compared to baseline | BLOCK |
 | BLOCK | DIFF results available | Decision: new failures or not | SCAN (clean) or ROLLBACK (regressions) |
-| SCAN | No new failures | Sibling bugs searched, proposed to user | PREVENT |
-| PREVENT | Scan complete | Max 2 rules proposed, user approved/declined | VALIDATE |
+| SCAN | No new failures | Sibling bugs searched, proposed to user | LEARN |
+| LEARN | Scan complete | Spec updated + rules proposed, user approved/declined | VALIDATE |
 | VALIDATE | Prevention done | All quality gates pass | DONE |
 
 ## Phase 1: INVESTIGATE (Complex and Highly Complex Bugs)
@@ -182,16 +182,66 @@ If fix introduces regressions (DIFF fails):
 - Option B: Roll back, find a different approach
 - Option C: Escalate to user with evidence
 
-## PREVENT: How To Update Rules to Avoid Recurrence
+## LEARN: Capture Learnings & Prevent Recurrence
 
-After SCAN, propose rule/memory updates so the same class of error doesn't happen again.
+After SCAN, capture what was learned so the same class of error doesn't recur. Two sub-steps: update the active spec (if one exists), then propose prevention rules for the agent's config files.
 
 **When to run:** Non-trivial bugs with a generalizable root cause.
-**When to skip:** Trivial bugs (typos, config), existing rule already covers it, emergency/hotfix.
+**When to skip:** Trivial bugs (typos, config), emergency/hotfix.
 
-### How To (follow exactly)
+### Step 1: Update Active Spec
 
-**Step 1: Identify the root cause category.**
+If the bug relates to an active spec in `specs/active/`, update it with the fix details.
+
+**1a. Check for active spec.**
+
+```
+Read specs/active/ directory
+  Files found? → Continue to 1b
+  Empty? → Skip to Step 2
+```
+
+**1b. Determine if bug relates to the active spec.**
+
+Read the spec file. Check:
+- Does the bug affect a scope item in this spec?
+- Was the bug found during implementation of this spec?
+- Does the fix change behavior described in the spec's ACs?
+
+If YES to any → continue. If NO to all → skip to Step 2.
+
+**1c. Log the bug in the spec.**
+
+Open the spec file. Find or create `## Encountered Bugs` section. Append:
+
+```markdown
+BUG-{N}: {1-line summary}
+- **Root cause:** {why it happened}
+- **Fix:** {what was changed}
+- **Status:** Fixed
+- **Regression test:** {test file}:{test name}
+```
+
+**1d. Update spec Progress section.**
+
+Find the `## Progress` table. If the bug blocked a scope item, update its status:
+- Was `[!] Blocked` → change to `[~] In progress` or `[x] Complete`
+- Add note: `Fixed via BUG-{N}`
+
+**1e. Update ACs if fix changed behavior.**
+
+If the fix changed how a feature works (not just a bug in implementation):
+- Update affected GIVEN/WHEN/THEN ACs to match new behavior
+- Add new AC if the fix introduced a new user-observable behavior
+- Run traceability check: every scope item maps to an AC, no orphans
+
+### Step 2: Propose Prevention Rules
+
+Propose rule updates to the agent's config files so the same class of error doesn't happen again.
+
+**When to skip this step:** Existing rule already covers it, or root cause is too specific to generalize.
+
+**2a. Identify the root cause category.**
 
 Look at the confirmed root cause from INVESTIGATE or GREEN phase. Map it:
 
@@ -205,13 +255,28 @@ Look at the confirmed root cause from INVESTIGATE or GREEN phase. Map it:
 | Missing edge case | Quality check | "Test empty/null/boundary inputs for public functions" |
 | Config/env assumption | Quality check | "Validate required env vars at startup" |
 
-**Step 2: Read existing agent rules.**
+**2b. Read existing agent rules.**
 
-Follow [memory-update.md](../memory-update.md) Step 1: detect which agent is running, then read all config files at both project-level and user-level. Use the Agent Config Targets table in memory-update.md to resolve the correct file paths for the detected agent.
+Detect which agent CLI is running, then read all config files at both project and user level to check for existing rules that already cover this root cause.
+
+**Where to look (by agent):**
+
+| Agent | Project-level config | User-level config |
+|-------|---------------------|-------------------|
+| Claude Code | `{project}/CLAUDE.md`, `{project}/.claude/CLAUDE.md`, `{project}/.claude/rules/*` | `~/.claude/CLAUDE.md`, `~/.claude/rules/*` |
+| Cursor | `{project}/.cursorrules` | `~/.cursorrules` |
+| Windsurf | `{project}/.windsurfrules` | `~/.windsurfrules` |
+| Codex | `{project}/codex.md` | `~/.codex/config` or `~/codex.md` |
+| OpenCode | `{project}/.opencode/config` | `~/.opencode/config` |
+| Aider | `{project}/.aider.conf.yml` | `~/.aider.conf.yml` |
+| Continue | `{project}/.continue/config.json` | `~/.continue/config.json` |
+| Any agent | `{project}/AGENTS.md` (universal fallback) | Ask user for path |
 
 If the root cause is already covered by an existing rule at any level → **SKIP**. Do not propose duplicates.
 
-**Step 3: Draft max 2 proposals.**
+Full protocol for reading/writing agent config: [memory-update.md](../memory-update.md).
+
+**2c. Draft max 2 proposals.**
 
 Write each proposal in this exact format:
 ```
@@ -219,15 +284,48 @@ Write each proposal in this exact format:
 _Prevents: {class of error}_
 ```
 
-Target file routing (resolve via [memory-update.md](../memory-update.md) Agent Config Targets table):
-- Project-specific patterns → `{project config}` (agent's project-level config)
-- Universal patterns → `{user config}` (agent's user-level config)
+Target file routing:
+- Project-specific patterns → agent's project-level config
+- Universal patterns → agent's user-level config
+- Unknown agent → `{project}/AGENTS.md` (universal fallback)
 
-Categories allowed: `rule` (coding rules), `anti-pattern`, `quality-check`. No process or thinking patterns.
+Categories allowed: `rule` (coding rules), `anti-pattern`, `quality-check`.
 
-**Step 4: Present to user for approval.**
+**Example proposals by agent:**
 
-If agent has multi-select UI (AskUserQuestion):
+Claude Code:
+```
+[{project}/CLAUDE.md § Coding Rules] rule: "Always null-check optional user fields (email, phone, avatar) before access"
+_Prevents: null reference errors on incomplete profiles_
+```
+
+Cursor:
+```
+[{project}/.cursorrules § Rules] rule: "Always null-check optional user fields before access"
+_Prevents: null reference errors on incomplete profiles_
+```
+
+Codex:
+```
+[{project}/codex.md § Rules] rule: "Always null-check optional user fields before access"
+_Prevents: null reference errors on incomplete profiles_
+```
+
+OpenCode:
+```
+[{project}/.opencode/config § Rules] rule: "Always null-check optional user fields before access"
+_Prevents: null reference errors on incomplete profiles_
+```
+
+Universal (any agent):
+```
+[{project}/AGENTS.md § Coding Rules] rule: "Always null-check optional user fields before access"
+_Prevents: null reference errors on incomplete profiles_
+```
+
+**2d. Present to user for approval.**
+
+If agent has multi-select UI (AskUserQuestion or equivalent):
 ```
 question: "Save prevention rules from this fix?"
 multiSelect: true
@@ -249,7 +347,7 @@ Prevention rules from this fix:
 Apply which? [all / 1,2 / none]
 ```
 
-**Step 5: Apply approved rules.**
+**2e. Apply approved rules.**
 
 For each approved proposal:
 1. Open the target file
@@ -259,12 +357,13 @@ For each approved proposal:
 
 Declined proposals → log in output, take no action.
 
-### PREVENT Rules
+### LEARN Rules
 
-- Max 2 proposals per fix
+- Max 2 rule proposals per fix
 - Advisory, not blocking — user can decline with no gate failure
-- Never auto-apply — always get explicit user approval before writing
+- Never auto-apply — always get explicit user approval before writing rules
 - Never propose vague rules ("be more careful") — must be specific and actionable
+- Spec updates don't require approval (they log facts, not opinions)
 
 ## Phase 3: VALIDATE
 
@@ -291,9 +390,8 @@ If your agent has built-in task/todo tracking (TaskCreate, TaskUpdate, etc.), us
 [ ] GREEN: implement fix, verify test passes
 [ ] DIFF: run full suite, compare to baseline (zero new failures)
 [ ] SCAN: check codebase for sibling bugs
-[ ] PREVENT: propose rules to avoid this class of bug
+[ ] LEARN: update spec (if related) + propose prevention rules
 [ ] Full pass: lint + typecheck + build + test
-[ ] Update spec (if related to active spec)
 [ ] Output summary
 ```
 
@@ -324,58 +422,6 @@ AC-B2 + AC-B3 = TDD proof. AC-B4 = anti-cascade proof.
 | Fix is trivial (typo, config) | Still run BASELINE + DIFF. Skip RED/GREEN only if no testable behavior change. |
 | Emergency/hotfix | Run abbreviated: RED + GREEN + DIFF. Skip SCAN. Document skip. |
 | User says "skip tests" | Document skip reason. Still run DIFF if suite exists (non-blocking). |
-
-## Spec Integration: How To Update Active Specs
-
-If the bug relates to an active spec in `specs/active/`, follow these steps exactly.
-
-### How To (follow exactly)
-
-**Step 1: Check for active spec.**
-
-```
-Read specs/active/ directory
-  Files found? → Continue to Step 2
-  Empty? → Skip to Spec-First Enforcement below
-```
-
-**Step 2: Determine if bug relates to the active spec.**
-
-Read the spec file. Check:
-- Does the bug affect a scope item in this spec?
-- Was the bug found during implementation of this spec?
-- Does the fix change behavior described in the spec's ACs?
-
-If YES to any → continue. If NO to all → skip (bug is independent).
-
-**Step 3: Log the bug in the spec.**
-
-Open the spec file. Find or create `## Encountered Bugs` section. Append:
-
-```markdown
-## Encountered Bugs
-
-BUG-{N}: {1-line summary}
-- **Root cause:** {why it happened}
-- **Fix:** {what was changed}
-- **Status:** Fixed
-- **Regression test:** {test file}:{test name}
-```
-
-**Step 4: Update spec Progress section.**
-
-Find the `## Progress` table. If the bug blocked a scope item, update its status:
-- Was `[!] Blocked` → change to `[~] In progress` or `[x] Complete`
-- Add note: `Fixed via BUG-{N}`
-
-**Step 5: Update ACs if fix changed behavior.**
-
-If the fix changed how a feature works (not just a bug in implementation):
-- Update affected GIVEN/WHEN/THEN ACs to match new behavior
-- Add new AC if the fix introduced a new user-observable behavior
-- Run traceability check: every scope item maps to an AC, no orphans
-
-If no active spec exists, follow Spec-First Enforcement below.
 
 ## Spec-First Enforcement
 
@@ -416,8 +462,8 @@ Always document any skipped steps in output.
 ## Never
 
 - Never auto-fix sibling bugs without user approval
-- Never auto-apply prevention rules — always propose, user approves
-- Never propose more than 2 prevention rules per fix
+- Never auto-apply prevention rules — always propose, user approves (LEARN step)
+- Never propose more than 2 prevention rules per fix (LEARN step)
 - Never skip BASELINE + DIFF (anti-cascade core)
 - Never make a change without a hypothesis (complex bugs)
 - Never runs `git push`

--- a/workflow/references/actions/fix.md
+++ b/workflow/references/actions/fix.md
@@ -207,12 +207,31 @@ Look at the confirmed root cause from INVESTIGATE or GREEN phase. Map it:
 
 **Step 2: Read existing agent rules.**
 
-Detect which agent is running and read the correct config files:
-- Claude Code → read `{project}/CLAUDE.md` + `~/.claude/CLAUDE.md` + `~/.claude/rules/`
-- Other agents → read `{project}/AGENTS.md` + agent-specific user config
-- See [memory-update.md](../memory-update.md) Step 1 and Agent Config Targets table for full routing
+Detect which agent is running and read **all** config files at both levels:
 
-If the root cause is already covered by an existing rule → **SKIP**. Do not propose duplicates.
+```
+Project-level (check all that exist):
+  {project}/CLAUDE.md
+  {project}/.claude/rules/*
+  {project}/.claude/CLAUDE.md
+  {project}/AGENTS.md
+  {project}/.cursorrules
+  {project}/.windsurfrules
+  {project}/.aider.conf.yml
+  {project}/.continue/config.json
+
+User-level (check all that exist):
+  ~/.claude/CLAUDE.md
+  ~/.claude/rules/*
+  ~/.cursorrules
+  ~/.windsurfrules
+  ~/.aider.conf.yml
+  ~/.continue/config.json
+```
+
+See [memory-update.md](../memory-update.md) Step 1 and Agent Config Targets table for full routing logic.
+
+If the root cause is already covered by an existing rule at any level → **SKIP**. Do not propose duplicates.
 
 **Step 3: Draft max 2 proposals.**
 

--- a/workflow/references/actions/fix.md
+++ b/workflow/references/actions/fix.md
@@ -1,0 +1,202 @@
+# Fix Action
+
+> **Agent:** Load this file when `fix` triggers. Also load `references/quality-gates.md` for gate commands and `references/session-management.md` for resume/stuck detection.
+
+Fix bugs with scientific debugging and anti-cascade TDD. Prevents cascading failures.
+
+---
+
+## When to Fix
+
+- User reports a bug (symptom, reproduction steps)
+- Bug found during feature implementation (ship's Bug Encounter Protocol hands off here)
+- Regression detected in CI or test suite
+
+## Bug Classification
+
+| Type | Signal | Approach |
+|------|--------|----------|
+| Simple | Clear cause, single file | Skip Phase 1, go directly to Phase 2 |
+| Complex | Unclear cause, multiple files, intermittent | Full Phase 1 (investigate) then Phase 2 |
+
+## Flow
+
+```
+fix {bug description}
+  │
+  ▼
+┌──────────────────────────────────────┐
+│ CLASSIFY: simple or complex?         │
+└──────────┬───────────────────────────┘
+           │
+     ┌─────┴─────┐
+     │           │
+  complex     simple
+     │           │
+     ▼           │
+┌────────────┐   │
+│ Phase 1:   │   │
+│ INVESTIGATE│   │
+│ (debug.md) │   │
+└─────┬──────┘   │
+      │          │
+      ▼          ▼
+┌──────────────────────────────────────┐
+│ Phase 2: FIX (anti-cascade TDD)     │
+│ BASELINE → RED → GREEN → DIFF →    │
+│ BLOCK → SCAN → PREVENT              │
+└──────────┬───────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────┐
+│ Phase 3: VALIDATE                    │
+│ lint → typecheck → build → test     │
+└──────────────────────────────────────┘
+```
+
+## Phase 1: INVESTIGATE (Complex Bugs Only)
+
+Load [patterns/debugging.md](../patterns/debugging.md) for full method.
+
+```
+1. SYMPTOM CAPTURE
+   - Exact error message/behavior
+   - Steps to reproduce
+   - When it started (last known good state)
+
+2. HYPOTHESIS FORMATION
+   Rank by likelihood:
+   H1: {most likely cause} (probability: X%)
+   H2: {second most likely} (probability: Y%)
+   H3: {least likely} (probability: Z%)
+
+3. TEST HYPOTHESES
+   For each (highest probability first):
+     Design minimal test → execute → CONFIRMED / ELIMINATED
+
+4. BINARY SEARCH (if no hypothesis confirmed)
+   git bisect or manual binary elimination
+
+5. ROOT CAUSE CONFIRMATION
+   Can you explain WHY it broke, not just WHERE?
+```
+
+**Key rule:** Never make a change without a hypothesis for why it will fix the bug.
+
+## Phase 2: FIX (Anti-Cascade TDD)
+
+All bug fixes follow this protocol. Full details: [regression-testing.md](../patterns/regression-testing.md).
+
+```
+1. BASELINE → Run full test suite, record pass/fail counts
+2. RED      → Write test reproducing the bug (MUST FAIL)
+3. GREEN    → Implement fix, verify regression test passes
+4. DIFF     → Run full test suite again, compare to baseline
+5. BLOCK    → Any NEW failures = fix introduced regressions → roll back, rethink
+6. SCAN     → Check codebase for sibling bugs (same pattern)
+```
+
+**DIFF is the anti-cascade mechanism.** By comparing full suite results before and after, you catch any regression the fix introduces — before it cascades.
+
+If fix introduces regressions (DIFF fails):
+- Option A: Fix regressions without breaking the original fix
+- Option B: Roll back, find a different approach
+- Option C: Escalate to user with evidence
+
+## Phase 3: VALIDATE
+
+Same quality gates as ship. Load `references/quality-gates.md`.
+
+**Full pass** (before marking complete):
+- Lint changed files
+- Typecheck full project
+- Build full project
+- Test related tests + anti-cascade DIFF
+
+Auto-detect tooling from project files.
+
+## Task Template
+
+```
+[ ] Classify bug (simple/complex)
+[ ] INVESTIGATE: scientific debugging (complex only)
+[ ] BASELINE: run full test suite, record results
+[ ] RED: write failing regression test
+[ ] GREEN: implement fix, verify test passes
+[ ] DIFF: run full suite, compare to baseline (zero new failures)
+[ ] SCAN: check codebase for sibling bugs
+[ ] Full pass: lint + typecheck + build + test
+[ ] Output summary
+```
+
+Update tasks as you work: mark in-progress when starting, complete when done. One task in-progress at a time.
+
+## Acceptance Criteria
+
+Auto-generate these ACs for any bug fix:
+
+```
+- AC-B1: GIVEN {reproduction steps} WHEN {trigger} THEN bug no longer occurs
+- AC-B2: GIVEN regression test WHEN run against unfixed code THEN test FAILS (RED)
+- AC-B3: GIVEN regression test WHEN run against fixed code THEN test PASSES (GREEN)
+- AC-B4: GIVEN full test suite WHEN run after fix THEN no NEW failures vs baseline
+```
+
+AC-B2 + AC-B3 = TDD proof. AC-B4 = anti-cascade proof.
+
+## Guard Rails
+
+| Situation | Action |
+|-----------|--------|
+| No test suite exists | Propose setup (link to testing-automation.md). If declined, document and proceed manually |
+| Test suite is partial (low coverage) | Warn: "Coverage is low near fix area. Baseline may miss regressions." |
+| Tests are flaky (intermittent failures) | Run baseline 2x, use consistent results as anchor. Flag flaky tests. |
+| Fix is trivial (typo, config) | Still run BASELINE + DIFF. Skip RED/GREEN only if no testable behavior change. |
+| Emergency/hotfix | Run abbreviated: RED + GREEN + DIFF. Skip SCAN. Document skip. |
+| User says "skip tests" | Document skip reason. Still run DIFF if suite exists (non-blocking). |
+
+## Spec-First Enforcement
+
+```
+Has spec?
+  YES → Continue
+  NO  → Estimate size
+    trivial (<5 LOC)  → Fix directly, no spec
+    micro (<30 LOC)   → Create inline comment spec
+    mini (<100 LOC)   → Create spec file (minimal)
+    standard (100+)   → Create full spec (suggest `plan` first)
+    emergency/hotfix   → Skip spec, log reason
+```
+
+## Session Management
+
+Uses same state machine as ship (see [session-management.md](../session-management.md)).
+
+Resume detects which phase was last completed:
+- No progress → FRESH (start from classify)
+- Phase 1 complete → Resume at Phase 2 (BASELINE)
+- Mid-Phase 2 → Resume at last completed TDD step
+
+## Output
+
+Follow the output template in `references/templates/fix-output.md`.
+
+## Intent Auto-Detection
+
+| User Says | Agent Does |
+|-----------|-----------|
+| "emergency fix", "hotfix" | Skip spec ceremony, abbreviated TDD (RED + GREEN + DIFF) |
+| "skip tests", "don't run tests" | Skip test gate (log reason) |
+| "fix this too", "also fix" | Run SCAN-style sibling check |
+
+Always document any skipped steps in output.
+
+## Never
+
+- Never auto-fix sibling bugs without user approval
+- Never skip BASELINE + DIFF (anti-cascade core)
+- Never make a change without a hypothesis (complex bugs)
+- Never runs `git push`
+- Never runs deploy commands
+- Never makes production changes
+- Never runs destructive git commands (`reset --hard`, `clean -f`, `push --force`)

--- a/workflow/references/actions/fix.md
+++ b/workflow/references/actions/fix.md
@@ -19,46 +19,31 @@ Fix bugs with scientific debugging and anti-cascade TDD. Prevents cascading fail
 | Simple | Clear cause, single file | Skip Phase 1, go directly to Phase 2 |
 | Complex | Unclear cause, multiple files, intermittent | Full Phase 1 (investigate) then Phase 2 |
 
-## Flow
+## State Machine
 
 ```
-fix {bug description}
-  │
-  ▼
-┌──────────────────────────────────────┐
-│ CLASSIFY: simple or complex?         │
-└──────────┬───────────────────────────┘
-           │
-     ┌─────┴─────┐
-     │           │
-  complex     simple
-     │           │
-     ▼           │
-┌────────────┐   │
-│ Phase 1:   │   │
-│ INVESTIGATE│   │
-│ (debug.md) │   │
-└─────┬──────┘   │
-      │          │
-      ▼          ▼
-┌──────────────────────────────────────┐
-│ Phase 2: FIX (anti-cascade TDD)     │
-│ BASELINE → RED → GREEN → DIFF →    │
-│ BLOCK → SCAN                         │
-└──────────┬───────────────────────────┘
-           │
-           ▼
-┌──────────────────────────────────────┐
-│ PREVENT: propose rules to avoid      │
-│ recurrence (max 2, advisory)         │
-└──────────┬───────────────────────────┘
-           │
-           ▼
-┌──────────────────────────────────────┐
-│ Phase 3: VALIDATE                    │
-│ lint → typecheck → build → test     │
-└──────────────────────────────────────┘
+CLASSIFY → simple?  → BASELINE
+CLASSIFY → complex? → INVESTIGATE → BASELINE
+
+BASELINE → RED → GREEN → DIFF → BLOCK
+  BLOCK [new failures] → ROLLBACK → rethink approach → BASELINE
+  BLOCK [no new failures] → SCAN → PREVENT → VALIDATE → DONE
 ```
+
+**States:**
+
+| State | Entry condition | Exit condition | Next state |
+|-------|----------------|----------------|------------|
+| CLASSIFY | Fix triggered | Bug classified as simple or complex | INVESTIGATE (complex) or BASELINE (simple) |
+| INVESTIGATE | Complex bug | Root cause confirmed | BASELINE |
+| BASELINE | Investigation done (or simple bug) | Full suite results recorded | RED |
+| RED | Baseline recorded | Regression test written and FAILS | GREEN |
+| GREEN | RED test exists | Fix implemented, regression test PASSES | DIFF |
+| DIFF | Fix passes regression test | Full suite re-run, compared to baseline | BLOCK |
+| BLOCK | DIFF results available | Decision: new failures or not | SCAN (clean) or ROLLBACK (regressions) |
+| SCAN | No new failures | Sibling bugs searched, proposed to user | PREVENT |
+| PREVENT | Scan complete | Max 2 rules proposed, user approved/declined | VALIDATE |
+| VALIDATE | Prevention done | All quality gates pass | DONE |
 
 ## Phase 1: INVESTIGATE (Complex Bugs Only)
 
@@ -109,24 +94,18 @@ If fix introduces regressions (DIFF fails):
 - Option B: Roll back, find a different approach
 - Option C: Escalate to user with evidence
 
-## PREVENT: Update Rules to Avoid Recurrence
+## PREVENT: How To Update Rules to Avoid Recurrence
 
-After SCAN, analyze the root cause and propose rule/memory updates so the same class of error doesn't happen again.
+After SCAN, propose rule/memory updates so the same class of error doesn't happen again.
 
 **When to run:** Non-trivial bugs with a generalizable root cause.
 **When to skip:** Trivial bugs (typos, config), existing rule already covers it, emergency/hotfix.
 
-```
-1. CLASSIFY root cause → map to prevention category
-2. CHECK existing rules → read agent config (CLAUDE.md, AGENTS.md, user rules)
-3. PROPOSE max 2 rules → user approves/declines inline
+### How To (follow exactly)
 
-Output format per proposal:
-  [{target file} § {section}] {type}: "{rule text}"
-  _Prevents: {class of error}_
-```
+**Step 1: Identify the root cause category.**
 
-**Root cause → prevention category:**
+Look at the confirmed root cause from INVESTIGATE or GREEN phase. Map it:
 
 | Root Cause | Category | Example Rule |
 |-----------|----------|-------------|
@@ -138,12 +117,69 @@ Output format per proposal:
 | Missing edge case | Quality check | "Test empty/null/boundary inputs for public functions" |
 | Config/env assumption | Quality check | "Validate required env vars at startup" |
 
-**Rules:**
-- Max 2 proposals per fix — keeps it lightweight
-- Categories: coding rules, anti-patterns, quality checks only
-- Advisory, not blocking — user can decline
-- Uses same targeting logic as [memory-update.md](../memory-update.md) (agent-detection, file routing)
-- Never auto-apply — always propose, user approves
+**Step 2: Read existing agent rules.**
+
+Detect which agent is running and read the correct config files:
+- Claude Code → read `{project}/CLAUDE.md` + `~/.claude/CLAUDE.md` + `~/.claude/rules/`
+- Other agents → read `{project}/AGENTS.md` + agent-specific user config
+- See [memory-update.md](../memory-update.md) Step 1 and Agent Config Targets table for full routing
+
+If the root cause is already covered by an existing rule → **SKIP**. Do not propose duplicates.
+
+**Step 3: Draft max 2 proposals.**
+
+Write each proposal in this exact format:
+```
+[{target file} § {section}] {type}: "{rule text}"
+_Prevents: {class of error}_
+```
+
+Target file routing:
+- Project-specific patterns → `{project config}` (CLAUDE.md or AGENTS.md)
+- Universal patterns → `{user config}` (user-level rules)
+
+Categories allowed: `rule` (coding rules), `anti-pattern`, `quality-check`. No process or thinking patterns.
+
+**Step 4: Present to user for approval.**
+
+If agent has multi-select UI (AskUserQuestion):
+```
+question: "Save prevention rules from this fix?"
+multiSelect: true
+options:
+  - label: "#1 {short summary}"
+    description: "[{target file} § {section}] {type}: {rule text}"
+  - label: "#2 {short summary}"
+    description: "[{target file} § {section}] {type}: {rule text}"
+```
+
+If no multi-select UI (fallback):
+```
+Prevention rules from this fix:
+1. [{target file} § {section}] {type}: "{rule text}"
+   _Prevents: {class of error}_
+2. [{target file} § {section}] {type}: "{rule text}"
+   _Prevents: {class of error}_
+
+Apply which? [all / 1,2 / none]
+```
+
+**Step 5: Apply approved rules.**
+
+For each approved proposal:
+1. Open the target file
+2. Find the target section
+3. Append the rule text
+4. Confirm write to user
+
+Declined proposals → log in output, take no action.
+
+### PREVENT Rules
+
+- Max 2 proposals per fix
+- Advisory, not blocking — user can decline with no gate failure
+- Never auto-apply — always get explicit user approval before writing
+- Never propose vague rules ("be more careful") — must be specific and actionable
 
 ## Phase 3: VALIDATE
 
@@ -203,17 +239,55 @@ AC-B2 + AC-B3 = TDD proof. AC-B4 = anti-cascade proof.
 | Emergency/hotfix | Run abbreviated: RED + GREEN + DIFF. Skip SCAN. Document skip. |
 | User says "skip tests" | Document skip reason. Still run DIFF if suite exists (non-blocking). |
 
-## Spec Integration
+## Spec Integration: How To Update Active Specs
 
-If the bug relates to an active spec in `specs/active/`:
+If the bug relates to an active spec in `specs/active/`, follow these steps exactly.
+
+### How To (follow exactly)
+
+**Step 1: Check for active spec.**
 
 ```
-1. Log bug under "## Encountered Bugs" in the spec
-   Format: BUG-{N}: {summary} | Status: Fixed
-2. Record root cause and fix summary
-3. Update Progress section with fix status
-4. If fix changed scope items or ACs → update them
+Read specs/active/ directory
+  Files found? → Continue to Step 2
+  Empty? → Skip to Spec-First Enforcement below
 ```
+
+**Step 2: Determine if bug relates to the active spec.**
+
+Read the spec file. Check:
+- Does the bug affect a scope item in this spec?
+- Was the bug found during implementation of this spec?
+- Does the fix change behavior described in the spec's ACs?
+
+If YES to any → continue. If NO to all → skip (bug is independent).
+
+**Step 3: Log the bug in the spec.**
+
+Open the spec file. Find or create `## Encountered Bugs` section. Append:
+
+```markdown
+## Encountered Bugs
+
+BUG-{N}: {1-line summary}
+- **Root cause:** {why it happened}
+- **Fix:** {what was changed}
+- **Status:** Fixed
+- **Regression test:** {test file}:{test name}
+```
+
+**Step 4: Update spec Progress section.**
+
+Find the `## Progress` table. If the bug blocked a scope item, update its status:
+- Was `[!] Blocked` → change to `[~] In progress` or `[x] Complete`
+- Add note: `Fixed via BUG-{N}`
+
+**Step 5: Update ACs if fix changed behavior.**
+
+If the fix changed how a feature works (not just a bug in implementation):
+- Update affected GIVEN/WHEN/THEN ACs to match new behavior
+- Add new AC if the fix introduced a new user-observable behavior
+- Run traceability check: every scope item maps to an AC, no orphans
 
 If no active spec exists, follow Spec-First Enforcement below.
 

--- a/workflow/references/actions/fix.md
+++ b/workflow/references/actions/fix.md
@@ -28,8 +28,11 @@ CLASSIFY → complex?        → INVESTIGATE → CONFIRM → BASELINE
 CLASSIFY → highly complex? → INVESTIGATE (parallel agents) → CONVERGE → CONFIRM → BASELINE
 
 BASELINE → RED → GREEN → DIFF → BLOCK
-  BLOCK [new failures] → ROLLBACK → rethink approach → BASELINE
+  BLOCK [new failures] → ROLLBACK → rethink approach → BASELINE (max 3 cycles → ESCALATE)
   BLOCK [no new failures] → SCAN → LEARN → VALIDATE → DONE
+
+INVESTIGATE → all hypotheses eliminated + bisect fails → ESCALATE
+ESCALATE → present evidence to user → user decides next step
 ```
 
 **States:**
@@ -37,13 +40,14 @@ BASELINE → RED → GREEN → DIFF → BLOCK
 | State | Entry condition | Exit condition | Next state |
 |-------|----------------|----------------|------------|
 | CLASSIFY | Fix triggered | Bug classified | INVESTIGATE (complex/highly complex) or BASELINE (simple) |
-| INVESTIGATE | Complex or highly complex bug | Hypotheses tested, candidate root cause identified | CONFIRM |
+| INVESTIGATE | Complex or highly complex bug | Hypotheses tested, candidate root cause identified | CONFIRM (or ESCALATE if exhausted) |
 | CONFIRM | Candidate root cause exists | Root cause passes 3-point validation | BASELINE |
 | BASELINE | Investigation done (or simple bug) | Full suite results recorded | RED |
 | RED | Baseline recorded | Regression test written and FAILS | GREEN |
 | GREEN | RED test exists | Fix implemented, regression test PASSES | DIFF |
 | DIFF | Fix passes regression test | Full suite re-run, compared to baseline | BLOCK |
-| BLOCK | DIFF results available | Decision: new failures or not | SCAN (clean) or ROLLBACK (regressions) |
+| BLOCK | DIFF results available | Decision: new failures or not | SCAN (clean) or ROLLBACK (regressions, max 3) |
+| ESCALATE | Investigation exhausted OR 3 rollback cycles | Evidence presented, user decides | User-directed (new approach, defer, or accept risk) |
 | SCAN | No new failures | Sibling bugs searched, proposed to user | LEARN |
 | LEARN | Scan complete | Spec updated + rules proposed, user approved/declined | VALIDATE |
 | VALIDATE | Prevention done | All quality gates pass | DONE |
@@ -136,7 +140,25 @@ git bisect or manual binary elimination:
   Read the breaking commit → form new hypothesis → test
 ```
 
-### Step 5: ROOT CAUSE CONFIRMATION
+### Step 5: ESCALATE (if investigation exhausted)
+
+If all hypotheses are eliminated AND binary search fails (or is not possible):
+
+```
+ESCALATE to user with:
+  1. Summary of all hypotheses tested and evidence
+  2. What was eliminated and why
+  3. Remaining unknowns
+  4. Recommended next steps:
+     a) Bring in domain expert / pair debug
+     b) Add instrumentation and wait for recurrence
+     c) Accept risk and document as known issue
+     d) Try different investigation angle (user suggests)
+```
+
+Do NOT loop back to Step 2 more than once after escalation. If the second round also fails → hard stop, present all evidence, let user decide.
+
+### Step 6: ROOT CAUSE CONFIRMATION
 
 Before proceeding to Phase 2, the root cause must pass **all 3 validation checks**:
 
@@ -158,7 +180,7 @@ Root Cause 3-Point Validation:
      If you can't toggle it → you found a correlation, not the cause.
 ```
 
-**If any check fails:** Do NOT proceed to Phase 2. Go back to Step 2 with new evidence and form new hypotheses.
+**If any check fails:** Do NOT proceed to Phase 2. Go back to Step 2 with new evidence and form new hypotheses. If this is the second failed round → ESCALATE (Step 5).
 
 **Key rule:** Never make a change without a hypothesis for why it will fix the bug.
 
@@ -181,6 +203,8 @@ If fix introduces regressions (DIFF fails):
 - Option A: Fix regressions without breaking the original fix
 - Option B: Roll back, find a different approach
 - Option C: Escalate to user with evidence
+
+**ROLLBACK cap:** Max 3 BLOCK → ROLLBACK cycles. If the 3rd approach still introduces regressions → ESCALATE. Present all 3 attempts + their regressions to the user. Do not loop indefinitely.
 
 ## LEARN: Capture Learnings & Prevent Recurrence
 
@@ -377,6 +401,32 @@ AC-B2 + AC-B3 = TDD proof. AC-B4 = anti-cascade proof.
 | Fix is trivial (typo, config) | Still run BASELINE + DIFF. Skip RED/GREEN only if no testable behavior change. |
 | Emergency/hotfix | Run abbreviated: RED + GREEN + DIFF. Skip SCAN. Document skip. |
 | User says "skip tests" | Document skip reason. Still run DIFF if suite exists (non-blocking). |
+| Non-deterministic bug (race condition, heisenbug) | Use Concurrency analyzer perspective. RED test may need stress/repeated runs. If can't reproduce reliably → document conditions, write best-effort test, note uncertainty. |
+| Can't reproduce locally | Skip RED (can't write failing test). Investigate via logs/history/code review. Propose fix based on code analysis. Run DIFF to ensure no regressions. Document that RED was skipped and why. |
+| Root cause is in dependency | Document dependency + version. Propose workaround (pin version, patch, or wrapper). Do NOT attempt to fix external code. File upstream issue if applicable. |
+| Investigation exhausted (no root cause found) | ESCALATE with all evidence. Do NOT guess-and-fix. Present hypotheses tested + results to user. |
+
+## Time Limits
+
+### Investigation Time-Box
+
+| Bug Type | Max Investigation Time | Max Hypotheses | Escalation |
+|----------|----------------------|----------------|------------|
+| Simple | N/A (skip Phase 1) | N/A | — |
+| Complex | 30 min | 5 | ESCALATE with evidence |
+| Highly complex | 60 min | 8 (across all agents) | ESCALATE with evidence |
+
+If time-box expires without confirmed root cause → ESCALATE (Step 5). Do not continue investigating indefinitely.
+
+### Fix Iteration Limits
+
+| Bug Complexity | Max ROLLBACK Cycles | Max Total Fix Time |
+|----------------|--------------------|--------------------|
+| Simple | 2 | 30 min |
+| Complex | 3 | 60 min |
+| Highly complex | 3 | 90 min |
+
+Exceeding any limit → ESCALATE to user with all evidence collected.
 
 ## Spec-First Enforcement
 

--- a/workflow/references/actions/fix.md
+++ b/workflow/references/actions/fix.md
@@ -44,7 +44,13 @@ fix {bug description}
 ┌──────────────────────────────────────┐
 │ Phase 2: FIX (anti-cascade TDD)     │
 │ BASELINE → RED → GREEN → DIFF →    │
-│ BLOCK → SCAN → PREVENT              │
+│ BLOCK → SCAN                         │
+└──────────┬───────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────┐
+│ PREVENT: propose rules to avoid      │
+│ recurrence (max 2, advisory)         │
 └──────────┬───────────────────────────┘
            │
            ▼
@@ -103,6 +109,42 @@ If fix introduces regressions (DIFF fails):
 - Option B: Roll back, find a different approach
 - Option C: Escalate to user with evidence
 
+## PREVENT: Update Rules to Avoid Recurrence
+
+After SCAN, analyze the root cause and propose rule/memory updates so the same class of error doesn't happen again.
+
+**When to run:** Non-trivial bugs with a generalizable root cause.
+**When to skip:** Trivial bugs (typos, config), existing rule already covers it, emergency/hotfix.
+
+```
+1. CLASSIFY root cause → map to prevention category
+2. CHECK existing rules → read agent config (CLAUDE.md, AGENTS.md, user rules)
+3. PROPOSE max 2 rules → user approves/declines inline
+
+Output format per proposal:
+  [{target file} § {section}] {type}: "{rule text}"
+  _Prevents: {class of error}_
+```
+
+**Root cause → prevention category:**
+
+| Root Cause | Category | Example Rule |
+|-----------|----------|-------------|
+| Missing null/undefined check | Coding rule | "Always null-check optional fields before access" |
+| Wrong type assumption | Coding rule | "Use discriminated unions, never assume shape" |
+| Missing validation at boundary | Quality check | "Validate external input at API boundaries" |
+| Incorrect error handling | Anti-pattern | "Never swallow errors in catch blocks" |
+| Race condition / shared state | Coding rule | "Wrap shared state mutations in transactions" |
+| Missing edge case | Quality check | "Test empty/null/boundary inputs for public functions" |
+| Config/env assumption | Quality check | "Validate required env vars at startup" |
+
+**Rules:**
+- Max 2 proposals per fix — keeps it lightweight
+- Categories: coding rules, anti-patterns, quality checks only
+- Advisory, not blocking — user can decline
+- Uses same targeting logic as [memory-update.md](../memory-update.md) (agent-detection, file routing)
+- Never auto-apply — always propose, user approves
+
 ## Phase 3: VALIDATE
 
 Same quality gates as ship. Load `references/quality-gates.md`.
@@ -115,7 +157,9 @@ Same quality gates as ship. Load `references/quality-gates.md`.
 
 Auto-detect tooling from project files.
 
-## Task Template
+## Task Tracking (Use Agent Capabilities)
+
+If your agent has built-in task/todo tracking (TaskCreate, TaskUpdate, etc.), use it to track each phase. Create tasks at the start, update status as you progress.
 
 ```
 [ ] Classify bug (simple/complex)
@@ -125,11 +169,15 @@ Auto-detect tooling from project files.
 [ ] GREEN: implement fix, verify test passes
 [ ] DIFF: run full suite, compare to baseline (zero new failures)
 [ ] SCAN: check codebase for sibling bugs
+[ ] PREVENT: propose rules to avoid this class of bug
 [ ] Full pass: lint + typecheck + build + test
+[ ] Update spec (if related to active spec)
 [ ] Output summary
 ```
 
 Update tasks as you work: mark in-progress when starting, complete when done. One task in-progress at a time.
+
+**If agent lacks task tracking:** Track progress in the spec's Progress section instead.
 
 ## Acceptance Criteria
 
@@ -154,6 +202,20 @@ AC-B2 + AC-B3 = TDD proof. AC-B4 = anti-cascade proof.
 | Fix is trivial (typo, config) | Still run BASELINE + DIFF. Skip RED/GREEN only if no testable behavior change. |
 | Emergency/hotfix | Run abbreviated: RED + GREEN + DIFF. Skip SCAN. Document skip. |
 | User says "skip tests" | Document skip reason. Still run DIFF if suite exists (non-blocking). |
+
+## Spec Integration
+
+If the bug relates to an active spec in `specs/active/`:
+
+```
+1. Log bug under "## Encountered Bugs" in the spec
+   Format: BUG-{N}: {summary} | Status: Fixed
+2. Record root cause and fix summary
+3. Update Progress section with fix status
+4. If fix changed scope items or ACs → update them
+```
+
+If no active spec exists, follow Spec-First Enforcement below.
 
 ## Spec-First Enforcement
 
@@ -194,6 +256,8 @@ Always document any skipped steps in output.
 ## Never
 
 - Never auto-fix sibling bugs without user approval
+- Never auto-apply prevention rules — always propose, user approves
+- Never propose more than 2 prevention rules per fix
 - Never skip BASELINE + DIFF (anti-cascade core)
 - Never make a change without a hypothesis (complex bugs)
 - Never runs `git push`

--- a/workflow/references/actions/fix.md
+++ b/workflow/references/actions/fix.md
@@ -17,13 +17,15 @@ Fix bugs with scientific debugging and anti-cascade TDD. Prevents cascading fail
 | Type | Signal | Approach |
 |------|--------|----------|
 | Simple | Clear cause, single file | Skip Phase 1, go directly to Phase 2 |
-| Complex | Unclear cause, multiple files, intermittent | Full Phase 1 (investigate) then Phase 2 |
+| Complex | Unclear cause, multiple files, intermittent | Phase 1 (single-agent investigation) then Phase 2 |
+| Highly complex | Cross-cutting, multiple possible root causes, reproduces inconsistently | Phase 1 with multi-agent parallel investigation then Phase 2 |
 
 ## State Machine
 
 ```
-CLASSIFY → simple?  → BASELINE
-CLASSIFY → complex? → INVESTIGATE → BASELINE
+CLASSIFY → simple?         → BASELINE
+CLASSIFY → complex?        → INVESTIGATE → CONFIRM → BASELINE
+CLASSIFY → highly complex? → INVESTIGATE (parallel agents) → CONVERGE → CONFIRM → BASELINE
 
 BASELINE → RED → GREEN → DIFF → BLOCK
   BLOCK [new failures] → ROLLBACK → rethink approach → BASELINE
@@ -34,8 +36,9 @@ BASELINE → RED → GREEN → DIFF → BLOCK
 
 | State | Entry condition | Exit condition | Next state |
 |-------|----------------|----------------|------------|
-| CLASSIFY | Fix triggered | Bug classified as simple or complex | INVESTIGATE (complex) or BASELINE (simple) |
-| INVESTIGATE | Complex bug | Root cause confirmed | BASELINE |
+| CLASSIFY | Fix triggered | Bug classified | INVESTIGATE (complex/highly complex) or BASELINE (simple) |
+| INVESTIGATE | Complex or highly complex bug | Hypotheses tested, candidate root cause identified | CONFIRM |
+| CONFIRM | Candidate root cause exists | Root cause passes 3-point validation | BASELINE |
 | BASELINE | Investigation done (or simple bug) | Full suite results recorded | RED |
 | RED | Baseline recorded | Regression test written and FAILS | GREEN |
 | GREEN | RED test exists | Fix implemented, regression test PASSES | DIFF |
@@ -45,32 +48,114 @@ BASELINE → RED → GREEN → DIFF → BLOCK
 | PREVENT | Scan complete | Max 2 rules proposed, user approved/declined | VALIDATE |
 | VALIDATE | Prevention done | All quality gates pass | DONE |
 
-## Phase 1: INVESTIGATE (Complex Bugs Only)
+## Phase 1: INVESTIGATE (Complex and Highly Complex Bugs)
 
 Load [patterns/debugging.md](../patterns/debugging.md) for full method.
 
+### Step 1: SYMPTOM CAPTURE
+
 ```
-1. SYMPTOM CAPTURE
-   - Exact error message/behavior
-   - Steps to reproduce
-   - When it started (last known good state)
-
-2. HYPOTHESIS FORMATION
-   Rank by likelihood:
-   H1: {most likely cause} (probability: X%)
-   H2: {second most likely} (probability: Y%)
-   H3: {least likely} (probability: Z%)
-
-3. TEST HYPOTHESES
-   For each (highest probability first):
-     Design minimal test → execute → CONFIRMED / ELIMINATED
-
-4. BINARY SEARCH (if no hypothesis confirmed)
-   git bisect or manual binary elimination
-
-5. ROOT CAUSE CONFIRMATION
-   Can you explain WHY it broke, not just WHERE?
+Collect before doing anything else:
+  - Exact error message / unexpected behavior
+  - Steps to reproduce (minimal)
+  - When it started (last known good state / commit)
+  - Environment details (OS, runtime version, config)
+  - Frequency: always / intermittent / once
 ```
+
+### Step 2: HYPOTHESIS FORMATION
+
+```
+Generate ranked hypotheses:
+  H1: {most likely cause} (probability: X%)
+  H2: {second most likely} (probability: Y%)
+  H3: {least likely} (probability: Z%)
+
+Each hypothesis must:
+  - Name a specific code path or condition
+  - Be falsifiable (you can design a test that disproves it)
+  - State what evidence would CONFIRM vs ELIMINATE it
+```
+
+### Step 3: TEST HYPOTHESES
+
+For **complex** bugs (single-agent): test each hypothesis sequentially, highest probability first.
+
+For **highly complex** bugs (multi-agent): spawn parallel sub-agents to investigate different hypotheses or perspectives simultaneously.
+
+#### Highly Complex: Multi-Agent Investigation
+
+When the bug is cross-cutting, has multiple plausible root causes, or spans several systems, use sub-agents to explore in parallel.
+
+**How to dispatch:**
+
+```
+Spawn up to 3 sub-agents in parallel, each with a focused investigation:
+
+Agent 1 (Explore, haiku): "Investigate H1: {hypothesis}. Search for {pattern}
+  in {area}. Report: evidence found, CONFIRMED or ELIMINATED, reasoning."
+
+Agent 2 (Explore, haiku): "Investigate H2: {hypothesis}. Search for {pattern}
+  in {area}. Report: evidence found, CONFIRMED or ELIMINATED, reasoning."
+
+Agent 3 (Explore, haiku): "Investigate H3: {hypothesis}. Alternatively, explore
+  {alternative angle — e.g., git history, dependency changes, config drift}.
+  Report: evidence found, CONFIRMED or ELIMINATED, reasoning."
+```
+
+**Agent perspective assignments (pick based on bug type):**
+
+| Perspective | Focus | When to use |
+|-------------|-------|-------------|
+| Code path tracer | Follow execution path, find where behavior diverges | Logic bugs, wrong output |
+| State inspector | Track state mutations, find unexpected side effects | State bugs, data corruption |
+| History investigator | git log/bisect, find breaking change, review recent commits | Regressions, "it used to work" |
+| Dependency auditor | Check dependency versions, breaking changes, API diffs | Post-upgrade bugs, integration issues |
+| Concurrency analyzer | Identify shared state, race windows, timing dependencies | Intermittent bugs, deadlocks |
+| Environment comparator | Diff configs, env vars, runtime versions across environments | "Works on my machine" bugs |
+
+**Convergence protocol:**
+
+```
+Collect all agent results → synthesize:
+  1. Which hypotheses were CONFIRMED? Which ELIMINATED?
+  2. Do agents agree on root cause? If not, what's the conflict?
+  3. If conflict → form new hypothesis from combined evidence → test directly
+  4. If no hypothesis confirmed → escalate to BINARY SEARCH (Step 4)
+```
+
+### Step 4: BINARY SEARCH (if no hypothesis confirmed)
+
+```
+git bisect or manual binary elimination:
+  Find last known good commit
+  Bisect to identify breaking change
+  Read the breaking commit → form new hypothesis → test
+```
+
+### Step 5: ROOT CAUSE CONFIRMATION
+
+Before proceeding to Phase 2, the root cause must pass **all 3 validation checks**:
+
+```
+Root Cause 3-Point Validation:
+
+  1. EXPLAINS: Does it explain ALL observed symptoms (not just some)?
+     Ask: "If this is the root cause, why does {symptom} happen?"
+     Every symptom must have an answer. If any symptom is unexplained → dig deeper.
+
+  2. PREDICTS: Does it predict the fix?
+     Ask: "If I change {specific code}, will the bug stop AND no new issues appear?"
+     Must be able to name the exact change. Vague fixes = wrong root cause.
+
+  3. REPRODUCES: Can you make the bug appear and disappear at will?
+     The reproduction case must:
+       - FAIL without the fix (proves the root cause triggers the bug)
+       - PASS with the fix (proves the fix addresses the root cause)
+     If you can't toggle it → you found a correlation, not the cause.
+```
+
+**If any check fails:** Do NOT proceed to Phase 2. Go back to Step 2 with new evidence and form new hypotheses.
 
 **Key rule:** Never make a change without a hypothesis for why it will fix the bug.
 
@@ -198,8 +283,9 @@ Auto-detect tooling from project files.
 If your agent has built-in task/todo tracking (TaskCreate, TaskUpdate, etc.), use it to track each phase. Create tasks at the start, update status as you progress.
 
 ```
-[ ] Classify bug (simple/complex)
-[ ] INVESTIGATE: scientific debugging (complex only)
+[ ] Classify bug (simple/complex/highly complex)
+[ ] INVESTIGATE: scientific debugging (complex/highly complex)
+[ ] CONFIRM: root cause passes 3-point validation
 [ ] BASELINE: run full test suite, record results
 [ ] RED: write failing regression test
 [ ] GREEN: implement fix, verify test passes

--- a/workflow/references/actions/fix.md
+++ b/workflow/references/actions/fix.md
@@ -257,24 +257,9 @@ Look at the confirmed root cause from INVESTIGATE or GREEN phase. Map it:
 
 **2b. Read existing agent rules.**
 
-Detect which agent CLI is running, then read all config files at both project and user level to check for existing rules that already cover this root cause.
-
-**Where to look (by agent):**
-
-| Agent | Project-level config | User-level config |
-|-------|---------------------|-------------------|
-| Claude Code | `{project}/CLAUDE.md`, `{project}/.claude/CLAUDE.md`, `{project}/.claude/rules/*` | `~/.claude/CLAUDE.md`, `~/.claude/rules/*` |
-| Cursor | `{project}/.cursorrules` | `~/.cursorrules` |
-| Windsurf | `{project}/.windsurfrules` | `~/.windsurfrules` |
-| Codex | `{project}/codex.md` | `~/.codex/config` or `~/codex.md` |
-| OpenCode | `{project}/.opencode/config` | `~/.opencode/config` |
-| Aider | `{project}/.aider.conf.yml` | `~/.aider.conf.yml` |
-| Continue | `{project}/.continue/config.json` | `~/.continue/config.json` |
-| Any agent | `{project}/AGENTS.md` (universal fallback) | Ask user for path |
+Detect which agent CLI is running, then read all config files at both project and user level. Use the **Agent Config Targets** table in [memory-update.md](../memory-update.md) to resolve the correct file paths for the detected agent.
 
 If the root cause is already covered by an existing rule at any level → **SKIP**. Do not propose duplicates.
-
-Full protocol for reading/writing agent config: [memory-update.md](../memory-update.md).
 
 **2c. Draft max 2 proposals.**
 
@@ -284,44 +269,14 @@ Write each proposal in this exact format:
 _Prevents: {class of error}_
 ```
 
-Target file routing:
+Target file routing (resolve via [memory-update.md](../memory-update.md) Agent Config Targets table):
 - Project-specific patterns → agent's project-level config
 - Universal patterns → agent's user-level config
 - Unknown agent → `{project}/AGENTS.md` (universal fallback)
 
 Categories allowed: `rule` (coding rules), `anti-pattern`, `quality-check`.
 
-**Example proposals by agent:**
-
-Claude Code:
-```
-[{project}/CLAUDE.md § Coding Rules] rule: "Always null-check optional user fields (email, phone, avatar) before access"
-_Prevents: null reference errors on incomplete profiles_
-```
-
-Cursor:
-```
-[{project}/.cursorrules § Rules] rule: "Always null-check optional user fields before access"
-_Prevents: null reference errors on incomplete profiles_
-```
-
-Codex:
-```
-[{project}/codex.md § Rules] rule: "Always null-check optional user fields before access"
-_Prevents: null reference errors on incomplete profiles_
-```
-
-OpenCode:
-```
-[{project}/.opencode/config § Rules] rule: "Always null-check optional user fields before access"
-_Prevents: null reference errors on incomplete profiles_
-```
-
-Universal (any agent):
-```
-[{project}/AGENTS.md § Coding Rules] rule: "Always null-check optional user fields before access"
-_Prevents: null reference errors on incomplete profiles_
-```
+See [memory-update.md](../memory-update.md) **Proposal Format Examples** for per-agent targeting (Claude Code, Cursor, Windsurf, Codex, OpenCode, etc.).
 
 **2d. Present to user for approval.**
 

--- a/workflow/references/actions/fix.md
+++ b/workflow/references/actions/fix.md
@@ -79,28 +79,31 @@ Each hypothesis must:
 
 ### Step 3: TEST HYPOTHESES
 
-For **complex** bugs (single-agent): test each hypothesis sequentially, highest probability first.
+For **complex** bugs: test each hypothesis sequentially, highest probability first.
 
-For **highly complex** bugs (multi-agent): spawn parallel sub-agents to investigate different hypotheses or perspectives simultaneously.
+For **highly complex** bugs: if the agent supports parallel execution (sub-agents, concurrent tool calls, or background tasks), investigate multiple hypotheses simultaneously. If not, investigate sequentially but assign a time box per hypothesis to avoid rabbit holes.
 
-#### Highly Complex: Multi-Agent Investigation
+#### Highly Complex: Parallel Investigation
 
-When the bug is cross-cutting, has multiple plausible root causes, or spans several systems, use sub-agents to explore in parallel.
+When the bug is cross-cutting, has multiple plausible root causes, or spans several systems, investigate from multiple perspectives at once.
 
-**How to dispatch:**
+**How to dispatch (adapt to your agent's capabilities):**
 
 ```
-Spawn up to 3 sub-agents in parallel, each with a focused investigation:
+For each hypothesis, create a focused investigation task:
 
-Agent 1 (Explore, haiku): "Investigate H1: {hypothesis}. Search for {pattern}
-  in {area}. Report: evidence found, CONFIRMED or ELIMINATED, reasoning."
+Task 1: "Investigate H1: {hypothesis}. Search for {pattern} in {area}.
+  Report: evidence found, CONFIRMED or ELIMINATED, reasoning."
 
-Agent 2 (Explore, haiku): "Investigate H2: {hypothesis}. Search for {pattern}
-  in {area}. Report: evidence found, CONFIRMED or ELIMINATED, reasoning."
+Task 2: "Investigate H2: {hypothesis}. Search for {pattern} in {area}.
+  Report: evidence found, CONFIRMED or ELIMINATED, reasoning."
 
-Agent 3 (Explore, haiku): "Investigate H3: {hypothesis}. Alternatively, explore
+Task 3: "Investigate H3: {hypothesis}. Alternatively, explore
   {alternative angle — e.g., git history, dependency changes, config drift}.
   Report: evidence found, CONFIRMED or ELIMINATED, reasoning."
+
+If agent supports sub-agents or parallel execution → run all tasks simultaneously.
+If agent is single-threaded → run sequentially, time-box each to 15 min max.
 ```
 
 **Agent perspective assignments (pick based on bug type):**

--- a/workflow/references/actions/fix.md
+++ b/workflow/references/actions/fix.md
@@ -207,29 +207,7 @@ Look at the confirmed root cause from INVESTIGATE or GREEN phase. Map it:
 
 **Step 2: Read existing agent rules.**
 
-Detect which agent is running and read **all** config files at both levels:
-
-```
-Project-level (check all that exist):
-  {project}/CLAUDE.md
-  {project}/.claude/rules/*
-  {project}/.claude/CLAUDE.md
-  {project}/AGENTS.md
-  {project}/.cursorrules
-  {project}/.windsurfrules
-  {project}/.aider.conf.yml
-  {project}/.continue/config.json
-
-User-level (check all that exist):
-  ~/.claude/CLAUDE.md
-  ~/.claude/rules/*
-  ~/.cursorrules
-  ~/.windsurfrules
-  ~/.aider.conf.yml
-  ~/.continue/config.json
-```
-
-See [memory-update.md](../memory-update.md) Step 1 and Agent Config Targets table for full routing logic.
+Follow [memory-update.md](../memory-update.md) Step 1: detect which agent is running, then read all config files at both project-level and user-level. Use the Agent Config Targets table in memory-update.md to resolve the correct file paths for the detected agent.
 
 If the root cause is already covered by an existing rule at any level → **SKIP**. Do not propose duplicates.
 
@@ -241,9 +219,9 @@ Write each proposal in this exact format:
 _Prevents: {class of error}_
 ```
 
-Target file routing:
-- Project-specific patterns → `{project config}` (CLAUDE.md or AGENTS.md)
-- Universal patterns → `{user config}` (user-level rules)
+Target file routing (resolve via [memory-update.md](../memory-update.md) Agent Config Targets table):
+- Project-specific patterns → `{project config}` (agent's project-level config)
+- Universal patterns → `{user config}` (agent's user-level config)
 
 Categories allowed: `rule` (coding rules), `anti-pattern`, `quality-check`. No process or thinking patterns.
 

--- a/workflow/references/actions/fix.md
+++ b/workflow/references/actions/fix.md
@@ -1,6 +1,6 @@
 # Fix Action
 
-> **Agent:** Load this file when `fix` triggers. Also load `references/quality-gates.md` for gate commands and `references/session-management.md` for resume/stuck detection.
+> **Agent:** Load this file when `fix` triggers. Also load `references/quality-gates.md` for gate commands, `references/testing-automation.md` for E2E-first test generation + mock avoidance, and `references/session-management.md` for resume/stuck detection.
 
 Fix bugs with scientific debugging and anti-cascade TDD. Prevents cascading failures.
 
@@ -189,15 +189,24 @@ Root Cause 3-Point Validation:
 All bug fixes follow this protocol. Full details: [regression-testing.md](../patterns/regression-testing.md).
 
 ```
-1. BASELINE → Run full test suite, record pass/fail counts
-2. RED      → Write test reproducing the bug (MUST FAIL)
-3. GREEN    → Implement fix, verify regression test passes
-4. DIFF     → Run full test suite again, compare to baseline
-5. BLOCK    → Any NEW failures = fix introduced regressions → roll back, rethink
-6. SCAN     → Check codebase for sibling bugs (same pattern)
+1. BASELINE → Run full test suite, record pass/fail counts (BLOCKING)
+2. RED      → Write E2E regression test reproducing the bug (MUST FAIL) (BLOCKING)
+               Log RED_CONFIRMED in e2e-scenarios registry
+               Use real systems — never mock own code (see testing-automation.md mock avoidance hierarchy)
+               Even if bug is in a "unit-testable" function → E2E proves fix at system level
+3. GREEN    → Implement fix, E2E regression test MUST PASS (BLOCKING)
+               Log GREEN_CONFIRMED in e2e-scenarios registry
+               No mocking own code — real DB, real server, real auth
+4. DIFF     → Run full test suite again, compare to baseline (BLOCKING)
+5. BLOCK    → Any NEW failures = fix introduced regressions → roll back, rethink (BLOCKING)
+6. SCAN     → Check codebase for sibling bugs (same pattern) (advisory)
 ```
 
+**All steps except SCAN are BLOCKING — cannot skip.**
+
 **DIFF is the anti-cascade mechanism.** By comparing full suite results before and after, you catch any regression the fix introduces — before it cascades.
+
+**Mock boundary:** Regression tests follow the same mock avoidance hierarchy as all tests (see `references/testing-automation.md`). DENY mocking own application code, own DB, own HTTP endpoints, own auth. ALLOW mocking only third-party APIs without sandbox/Docker/in-memory alternatives.
 
 If fix introduces regressions (DIFF fails):
 - Option A: Fix regressions without breaking the original fix
@@ -243,7 +252,8 @@ BUG-{N}: {1-line summary}
 - **Root cause:** {why it happened}
 - **Fix:** {what was changed}
 - **Status:** Fixed
-- **Regression test:** {test file}:{test name}
+- **Regression test:** {test file}:{test name} (E2E)
+- **Registry:** AC-B1 through AC-B4 in e2e-scenarios.md — RED_CONFIRMED + GREEN_CONFIRMED
 ```
 
 **1d. Update spec Progress section.**
@@ -348,13 +358,19 @@ Declined proposals → log in output, take no action.
 
 Same quality gates as ship. Load `references/quality-gates.md`.
 
-**Full pass** (before marking complete):
-- Lint changed files
-- Typecheck full project
-- Build full project
-- Test related tests + anti-cascade DIFF
+**Full pass** (before marking complete — all 6 gates + TDD proof):
 
-Auto-detect tooling from project files.
+| # | Gate | Scope | Level |
+|---|------|-------|-------|
+| 1 | Lint | Changed files | BLOCKING |
+| 2 | Typecheck | Full project | BLOCKING |
+| 3 | Build | Full project | BLOCKING |
+| 4 | Test | Related tests + anti-cascade DIFF | BLOCKING |
+| 5 | E2E registry | All bug fix ACs (AC-B1 through AC-B4) GREEN_CONFIRMED | BLOCKING |
+| 6 | TDD proof | Every GREEN_CONFIRMED has prior RED_CONFIRMED | BLOCKING |
+| 7 | Coverage | Advisory — warn on >5% drop | ADVISORY |
+
+Auto-detect tooling from project files. See `references/quality-gates.md`.
 
 ## Task Tracking (Use Agent Capabilities)
 
@@ -364,13 +380,15 @@ If your agent has built-in task/todo tracking (TaskCreate, TaskUpdate, etc.), us
 [ ] Classify bug (simple/complex/highly complex)
 [ ] INVESTIGATE: scientific debugging (complex/highly complex)
 [ ] CONFIRM: root cause passes 3-point validation
-[ ] BASELINE: run full test suite, record results
-[ ] RED: write failing regression test
-[ ] GREEN: implement fix, verify test passes
-[ ] DIFF: run full suite, compare to baseline (zero new failures)
+[ ] BASELINE: run full test suite, record results (BLOCKING)
+[ ] Create e2e-scenarios.md registry entries for bug fix ACs (AC-B1 through AC-B4)
+[ ] RED: write E2E regression test → MUST FAIL → log RED_CONFIRMED (BLOCKING)
+[ ] GREEN: implement fix → E2E test MUST PASS → log GREEN_CONFIRMED (BLOCKING)
+[ ] DIFF: run full suite, compare to baseline (zero new failures) (BLOCKING)
+[ ] Mock audit: verify no mocking of own code in regression test
 [ ] SCAN: check codebase for sibling bugs
 [ ] LEARN: update spec (if related) + propose prevention rules
-[ ] Full pass: lint + typecheck + build + test
+[ ] Full pass: lint + typecheck + build + test + E2E registry + TDD proof + coverage
 [ ] Output summary
 ```
 
@@ -384,18 +402,21 @@ Auto-generate these ACs for any bug fix:
 
 ```
 - AC-B1: GIVEN {reproduction steps} WHEN {trigger} THEN bug no longer occurs
-- AC-B2: GIVEN regression test WHEN run against unfixed code THEN test FAILS (RED)
-- AC-B3: GIVEN regression test WHEN run against fixed code THEN test PASSES (GREEN)
-- AC-B4: GIVEN full test suite WHEN run after fix THEN no NEW failures vs baseline
+- AC-B2: GIVEN E2E regression test WHEN run against unfixed code THEN test FAILS (RED_CONFIRMED in registry)
+- AC-B3: GIVEN E2E regression test WHEN run against fixed code THEN test PASSES (GREEN_CONFIRMED in registry)
+- AC-B4: GIVEN full test suite WHEN run after fix THEN no NEW failures vs baseline (DIFF clean)
 ```
 
-AC-B2 + AC-B3 = TDD proof. AC-B4 = anti-cascade proof.
+AC-B2 + AC-B3 = TDD proof (tracked in `e2e-scenarios.md` registry). AC-B4 = anti-cascade proof.
+
+All bug fix ACs are registered in `e2e-scenarios.md` with type prefix `AC-BN`. See `references/e2e-scenarios.md` for registry format.
 
 ## Guard Rails
 
 | Situation | Action |
 |-----------|--------|
-| No test suite exists | Propose setup (link to testing-automation.md). If declined, document and proceed manually |
+| No test suite exists | Propose setup (load testing-automation.md for recommendation). If declined, document and downgrade E2E gate to ADVISORY |
+| No E2E framework exists | Propose E2E framework setup (Playwright/Cypress/Maestro/Detox per stack). If declined, downgrade E2E gate to ADVISORY for this session |
 | Test suite is partial (low coverage) | Warn: "Coverage is low near fix area. Baseline may miss regressions." |
 | Tests are flaky (intermittent failures) | Run baseline 2x, use consistent results as anchor. Flag flaky tests. |
 | Fix is trivial (typo, config) | Still run BASELINE + DIFF. Skip RED/GREEN only if no testable behavior change. |

--- a/workflow/references/actions/ship.md
+++ b/workflow/references/actions/ship.md
@@ -203,6 +203,19 @@ When a bug is found during feature implementation:
 5. All bugs must be Fixed or Deferred before `done`
 ```
 
+**Resume after fix:** When the `fix` action completes, it updates the spec's Encountered Bugs section and Progress table (LEARN step). Ship resumes automatically:
+
+```
+fix completes → spec updated with BUG-{N} status: Fixed
+  → ship detects RESUMING state (session-management.md)
+  → reads spec Progress section
+  → finds first non-[x] scope item
+  → continues implementation from that point
+  → runs quick quality pass before continuing
+```
+
+The handoff is seamless because both actions share the same spec file and session management state machine.
+
 ## Review Integration
 
 Review runs automatically during ship loop. Perspectives:

--- a/workflow/references/actions/ship.md
+++ b/workflow/references/actions/ship.md
@@ -4,6 +4,8 @@
 
 Implement features with a build/review/fix loop. Handles both quick one-shot and iterative spec-driven work.
 
+**Bug fix?** Use the `fix` action instead. See [fix.md](fix.md).
+
 ---
 
 ## Mode Detection
@@ -30,16 +32,6 @@ Before starting any implementation, create tasks in your agent's built-in task/t
 [ ] Fix BLOCKING issues
 [ ] Full pass: lint (changed) + typecheck (full) + build (full) + test (related) + E2E (registry) + coverage (advisory)
 [ ] Exit check: all Must Have ACs + Error ACs + scope items + e2e_coverage passing
-```
-
-**Bug mode tasks (replace scope items above):**
-```
-[ ] BASELINE: run full test suite, record results (BLOCKING)
-[ ] RED: write failing E2E regression test — MUST FAIL (BLOCKING)
-[ ] GREEN: implement fix, E2E test MUST PASS — no mocking own code (BLOCKING)
-[ ] DIFF: run full suite, compare to baseline — zero new failures (BLOCKING)
-[ ] SCAN: check codebase for sibling bugs (propose only)
-[ ] PREVENT: propose prevention rules (max 2, advisory, non-trivial bugs only)
 ```
 
 Update tasks as you work: mark in-progress when starting, complete when done. One task in-progress at a time.
@@ -73,54 +65,6 @@ Has spec?
     standard (100+)   → Create full spec (suggest `plan` first)
     emergency/hotfix   → Skip spec, log reason
 ```
-
-## Bug Mode Detection
-
-When fixing bugs, classify:
-
-| Type | Signal | Approach |
-|------|--------|----------|
-| Simple | Clear cause, single file | Anti-cascade TDD (below) |
-| Complex | Unclear cause, multiple files, intermittent | Scientific debugging (see patterns/debugging.md) → then anti-cascade TDD |
-
-Complex bugs require scientific debugging FIRST:
-1. Symptom capture (exact error, reproduction steps)
-2. Hypothesis formation (ranked by likelihood)
-3. Evidence collection (binary search, instrumentation)
-4. Root cause confirmation
-5. Then apply anti-cascade TDD below
-
-### Anti-Cascade TDD Protocol (BLOCKING)
-
-All bug fixes follow this protocol. E2E regression tests required. Full details: [regression-testing.md](../patterns/regression-testing.md).
-
-```
-1. BASELINE → Run full test suite, record pass/fail counts (BLOCKING)
-2. RED      → Write E2E regression test reproducing bug (MUST FAIL) (BLOCKING)
-3. GREEN    → Implement fix, E2E test MUST PASS, no mocking own code (BLOCKING)
-4. DIFF     → Run full test suite again, compare to baseline (BLOCKING)
-5. BLOCK    → Any NEW failures = BLOCKING rollback — fix regressions or revert
-6. SCAN     → Check codebase for sibling bugs (same pattern) — propose only
-7. PREVENT  → Propose max 2 rules (advisory, user approves)
-```
-
-All steps except SCAN/PREVENT are BLOCKING — cannot skip.
-
-**DIFF is the anti-cascade mechanism.** By comparing full suite results before and after, you catch any regression the fix introduces — before it cascades.
-
-**PREVENT is lightweight:** max 2 proposals, inline approval, advisory (not blocking). Covers coding rules, anti-patterns, quality checks only. Skip for trivial bugs and emergencies. Full details: [regression-testing.md](../patterns/regression-testing.md) Step 7.
-
-If fix introduces regressions (DIFF fails):
-- Option A: Fix regressions without breaking the original fix
-- Option B: Roll back, find a different approach
-- Option C: Escalate to user with evidence
-
-**Bug fix ACs (auto-generate if not in spec):**
-- AC-B1: GIVEN {reproduction steps} WHEN {trigger} THEN bug no longer occurs
-- AC-B2: GIVEN E2E regression test WHEN run against unfixed code THEN test FAILS (RED_CONFIRMED)
-- AC-B3: GIVEN E2E regression test WHEN run against fixed code THEN test PASSES (GREEN_CONFIRMED)
-- AC-B4: GIVEN full test suite WHEN run after fix THEN no NEW failures vs baseline
-- **All AC-B entries logged in e2e-scenarios registry. AC-B2 + AC-B3 + AC-B4 are BLOCKING.**
 
 ## ONE-SHOT Flow
 
@@ -248,13 +192,13 @@ Three levels, triggered by lack of progress:
 
 ## Bug Encounter Protocol
 
-When a bug is found during implementation:
+When a bug is found during feature implementation:
 
 ```
 1. Log bug in spec under "## Encountered Bugs"
    Format: BUG-{N}: {summary} | Status: Investigating/Fixed/Deferred
 2. Classify: blocks current scope item? (Y/N)
-3. If blocking: fix immediately, add regression test
+3. If blocking: pause ship, run `fix` action (see fix.md)
 4. If non-blocking: defer, continue with scope
 5. All bugs must be Fixed or Deferred before `done`
 ```
@@ -365,7 +309,7 @@ No flags needed. The agent detects intent from natural language:
 
 | User Says | Agent Does |
 |-----------|-----------|
-| "emergency fix", "hotfix" | Skip spec ceremony |
+| "emergency fix", "hotfix" | Route to `fix` action with abbreviated mode |
 | "skip tests", "don't run tests" | Skip test gate (log reason) |
 | "skip review" | Skip review perspectives |
 | "deploy to production", "production ready" | Run production validation |

--- a/workflow/references/memory-update.md
+++ b/workflow/references/memory-update.md
@@ -173,6 +173,46 @@ If a target file doesn't exist, add a final item: "Create {file} with selected r
 - `{project}/AGENTS.md` is the universal fallback for any agent without its own project config
 - Auto-detect which agent is running. If unknown, ask the user.
 
+### Proposal Format Examples (by agent)
+
+When proposing a rule, target the correct file for the detected agent:
+
+Claude Code:
+```
+[{project}/CLAUDE.md § Coding Rules] rule: "Always null-check optional user fields before access"
+_Prevents: null reference errors on incomplete profiles_
+```
+
+Cursor:
+```
+[{project}/.cursorrules § Rules] rule: "Always null-check optional user fields before access"
+_Prevents: null reference errors on incomplete profiles_
+```
+
+Windsurf:
+```
+[{project}/.windsurfrules § Rules] rule: "Always null-check optional user fields before access"
+_Prevents: null reference errors on incomplete profiles_
+```
+
+Codex:
+```
+[{project}/codex.md § Rules] rule: "Always null-check optional user fields before access"
+_Prevents: null reference errors on incomplete profiles_
+```
+
+OpenCode:
+```
+[{project}/.opencode/config § Rules] rule: "Always null-check optional user fields before access"
+_Prevents: null reference errors on incomplete profiles_
+```
+
+Universal (any agent):
+```
+[{project}/AGENTS.md § Coding Rules] rule: "Always null-check optional user fields before access"
+_Prevents: null reference errors on incomplete profiles_
+```
+
 ## Rules
 
 - **Read before proposing** — ALWAYS read existing rules first. No blind proposals.

--- a/workflow/references/memory-update.md
+++ b/workflow/references/memory-update.md
@@ -1,8 +1,8 @@
 # Memory Update Protocol
 
-> **Agent:** Load this file during `done` Step 4. Read the user's agent config (global + project rules) before proposing.
+> **Agent:** Load this file whenever proposing rule/memory updates: `done` Step 4 (session learnings), `fix` PREVENT step (bug prevention rules), or any action that produces learnings worth persisting. Read the user's agent config (global + project rules) before proposing.
 
-After retro, propose updating the agent's persistent memory with learnings from this session.
+Shared protocol for reading agent config, classifying learnings, targeting the right files, and proposing updates. Used by multiple actions.
 
 ---
 
@@ -10,18 +10,32 @@ After retro, propose updating the agent's persistent memory with learnings from 
 
 **Before proposing anything, understand what already exists.**
 
-Detect which agent is running, then read the correct target files:
+Detect which agent is running, then read **all** config files that exist at both levels:
 
 ```
-Claude Code detected?
-  → Read {project}/CLAUDE.md (project root)
-  → Read ~/.claude/CLAUDE.md and ~/.claude/rules/ (user-level)
+Project-level (check all that exist):
+  {project}/CLAUDE.md
+  {project}/.claude/CLAUDE.md
+  {project}/.claude/rules/*
+  {project}/AGENTS.md
+  {project}/.cursorrules
+  {project}/.windsurfrules
+  {project}/.aider.conf.yml
+  {project}/.continue/config.json
+  {project}/codex.md
+  {project}/.opencode/config
 
-Other agent (Cursor, Windsurf, Aider, etc.)?
-  → Read {project}/AGENTS.md (universal agent config)
-  → Read agent-specific user-level config (see targets table)
+User-level (check all that exist):
+  ~/.claude/CLAUDE.md
+  ~/.claude/rules/*
+  ~/.cursorrules
+  ~/.windsurfrules
+  ~/.aider.conf.yml
+  ~/.continue/config.json
+  ~/.codex/config or ~/codex.md
+  ~/.opencode/config
 
-Neither file exists?
+No config files found at either level?
   → Flag for Step 4: propose creating with initial rules from session
 ```
 
@@ -70,21 +84,21 @@ For each learning, check:
 
 | Learning Type | Target Level | Where to Add |
 |---------------|-------------|--------------|
-| Thinking pattern (universal) | User-level | `~/.claude/CLAUDE.md` or `~/.claude/rules/` |
-| Thinking pattern (project) | Project-level | Claude Code → `{project}/CLAUDE.md`; Others → `{project}/AGENTS.md` |
-| Coding rule (universal) | User-level | `~/.claude/rules/coding-{language}.md` |
-| Coding rule (language-specific) | User-level | `~/.claude/rules/coding-{language}.md` |
-| Coding rule (project-specific) | Project-level | Claude Code → `{project}/CLAUDE.md`; Others → `{project}/AGENTS.md` |
-| Project convention | Project-level | Claude Code → `{project}/CLAUDE.md`; Others → `{project}/AGENTS.md` |
-| Quality check | Project-level | Claude Code → `{project}/CLAUDE.md`; Others → `{project}/AGENTS.md` |
-| Process rule (universal) | User-level | `~/.claude/CLAUDE.md` or `~/.claude/rules/` |
-| Process rule (project) | Project-level | Claude Code → `{project}/CLAUDE.md`; Others → `{project}/AGENTS.md` |
-| User preference (universal) | User-level | `~/.claude/CLAUDE.md` or `~/.claude/rules/` |
-| User preference (project-specific) | Project-level | Claude Code → `{project}/CLAUDE.md`; Others → `{project}/AGENTS.md` |
-| Anti-pattern (universal) | User-level | `~/.claude/CLAUDE.md` or `~/.claude/rules/` |
-| Anti-pattern (project-specific) | Project-level | Claude Code → `{project}/CLAUDE.md`; Others → `{project}/AGENTS.md` |
+| Thinking pattern (universal) | User-level | Agent's user-level config (see targets table) |
+| Thinking pattern (project) | Project-level | Agent's project-level config (see targets table) |
+| Coding rule (universal) | User-level | Agent's user-level config |
+| Coding rule (language-specific) | User-level | Agent's user-level config (prefer topic-specific file if supported) |
+| Coding rule (project-specific) | Project-level | Agent's project-level config |
+| Project convention | Project-level | Agent's project-level config |
+| Quality check | Project-level | Agent's project-level config |
+| Process rule (universal) | User-level | Agent's user-level config |
+| Process rule (project) | Project-level | Agent's project-level config |
+| User preference (universal) | User-level | Agent's user-level config |
+| User preference (project-specific) | Project-level | Agent's project-level config |
+| Anti-pattern (universal) | User-level | Agent's user-level config |
+| Anti-pattern (project-specific) | Project-level | Agent's project-level config |
 
-**Routing rule:** Claude Code project learnings → `{project}/CLAUDE.md`. All other agents → `{project}/AGENTS.md`. If target file doesn't exist → propose creating it in Step 4.
+**Routing rule:** Use the Agent Config Targets table below to resolve "agent's project/user-level config" to the correct file path. If the detected agent has both agent-specific and universal (`AGENTS.md`) project config, prefer agent-specific. If target file doesn't exist → propose creating it in Step 4.
 
 ## Step 4: Propose
 
@@ -133,9 +147,9 @@ Print numbered list, ask user to reply with numbers:
 **Type labels:** `rule`, `preference`, `anti-pattern`, `coding standard`, `pattern`
 
 **Target file shorthand:**
-- `P/CLAUDE.md` = `{project}/CLAUDE.md`
-- `P/AGENTS.md` = `{project}/AGENTS.md`
-- `~/CLAUDE.md` = `~/.claude/CLAUDE.md`
+- `{project config}` = agent's project-level config (resolved via Agent Config Targets table)
+- `{user config}` = agent's user-level config (resolved via Agent Config Targets table)
+- `P/AGENTS.md` = `{project}/AGENTS.md` (universal fallback)
 
 If a target file doesn't exist, add a final item: "Create {file} with selected rules? [y/n]"
 
@@ -143,18 +157,20 @@ If a target file doesn't exist, add a final item: "Create {file} with selected r
 
 | Agent | User-level | Project-level (agent-specific) | Project-level (universal) |
 |-------|-----------|-------------------------------|--------------------------|
-| Claude Code | `~/.claude/CLAUDE.md` or `~/.claude/rules/{topic}.md` | `{project}/CLAUDE.md` | `{project}/AGENTS.md` |
+| Claude Code | `~/.claude/CLAUDE.md` or `~/.claude/rules/{topic}.md` | `{project}/CLAUDE.md` or `{project}/.claude/rules/` | `{project}/AGENTS.md` |
 | Cursor | `~/.cursorrules` | `{project}/.cursorrules` | `{project}/AGENTS.md` |
 | Windsurf | `~/.windsurfrules` | `{project}/.windsurfrules` | `{project}/AGENTS.md` |
 | Aider | `~/.aider.conf.yml` | `{project}/.aider.conf.yml` | `{project}/AGENTS.md` |
 | Continue | `~/.continue/config.json` | `{project}/.continue/config.json` | `{project}/AGENTS.md` |
-| Codex | Agent config | Project config | `{project}/AGENTS.md` |
+| Codex | `~/.codex/config` or `~/codex.md` | `{project}/codex.md` | `{project}/AGENTS.md` |
+| OpenCode | `~/.opencode/config` | `{project}/.opencode/config` | `{project}/AGENTS.md` |
 | Other | Ask user for path | Ask user for path | `{project}/AGENTS.md` |
 
 **Routing logic:**
-- Claude Code project learnings → `{project}/CLAUDE.md` (standard location)
-- All other agents → `{project}/AGENTS.md` (universal agent config, project root)
-- Universal patterns (any agent) → user-level config
+- Detect which agent is running → use Agent Config Targets table to find correct file paths
+- Project-specific learnings → agent's project-level config (agent-specific column preferred)
+- Universal patterns → agent's user-level config
+- `{project}/AGENTS.md` is the universal fallback for any agent without its own project config
 - Auto-detect which agent is running. If unknown, ask the user.
 
 ## Rules

--- a/workflow/references/session-management.md
+++ b/workflow/references/session-management.md
@@ -1,6 +1,6 @@
 # Session Management
 
-> **Agent:** Load this file when `ship` references session/resume/stuck logic. Also loaded by `done` for context reload.
+> **Agent:** Load this file when `ship` or `fix` references session/resume/stuck logic. Also loaded by `done` for context reload.
 
 Track progress, detect stuck states, resume across sessions.
 
@@ -56,6 +56,8 @@ When `ship` is invoked, detect current state:
 | RESUMING | Resume from last incomplete scope item |
 | STUCK | Present escalation options to user |
 | READY_FOR_DONE | Suggest `done` |
+
+**Fix action resume:** For `fix` mode, RESUMING detects which TDD phase was last completed (BASELINE/RED/GREEN/DIFF) from the spec Progress section and resumes from the next incomplete phase.
 
 ## Resume Protocol
 

--- a/workflow/references/templates/fix-output.md
+++ b/workflow/references/templates/fix-output.md
@@ -1,0 +1,105 @@
+# Fix Output Template
+
+Edit this file to customize what the agent returns after `fix`. Decision logic: [actions/fix.md](../actions/fix.md).
+
+---
+
+## Fix Complete
+
+```markdown
+## Fix Complete
+
+**Bug:** {description}
+**Root cause:** {1-line cause}
+**Classification:** simple | complex
+**Fix:** {1-line what changed}
+
+### Anti-Cascade TDD
+**BASELINE:** {N} pass | {N} fail | {N} skipped
+**RED:** {test name} → FAIL (confirmed)
+**GREEN:** {what changed} → PASS
+**DIFF:** {N} pass | {N} fail | {N} skipped (zero new failures)
+**SCAN:** {N} sibling locations | {proposed/none found}
+
+### Quality Gates
+lint {OK/FAIL} | typecheck {OK/FAIL} | build {OK/FAIL} | test {OK/FAIL}
+
+Next: Run `done` to validate, retro, and archive.
+```
+
+---
+
+## Complex Bug Output
+
+When Phase 1 (INVESTIGATE) ran, prepend before Anti-Cascade TDD:
+
+```markdown
+### Investigation
+**Hypotheses:** {N} formed, {N} tested
+**Confirmed:** H{N} — {hypothesis description}
+**Evidence:** {key evidence that confirmed root cause}
+```
+
+---
+
+## Fix Blocked
+
+When DIFF detects regressions:
+
+```markdown
+## Fix Blocked
+
+**Bug:** {description}
+**Fix attempt:** {what was tried}
+**DIFF result:** {N} new failures detected
+
+**Regressions:**
+- {test name}: {what broke}
+
+Options: fix regressions (keep original fix) | roll back (different approach) | escalate
+```
+
+---
+
+## Fix Abbreviated
+
+For emergency/hotfix (skipped steps):
+
+```markdown
+## Fix Complete (Emergency)
+
+**Bug:** {description}
+**Fix:** {what changed}
+**RED:** {test name} → FAIL
+**GREEN:** → PASS
+**DIFF:** {N} pass | {N} fail (zero new failures)
+**Skipped:** {INVESTIGATE / SCAN / spec ceremony}
+**Reason:** {why skipped}
+
+Next: Run `done` to validate, retro, and archive.
+```
+
+---
+
+## Example: Full Bug Fix
+
+```markdown
+## Fix Complete
+
+**Bug:** Null reference on user.email when profile incomplete
+**Root cause:** getDisplayName() assumes email is always populated
+**Classification:** simple
+**Fix:** Added null check with fallback to username
+
+### Anti-Cascade TDD
+**BASELINE:** 42 pass | 0 fail | 2 skipped
+**RED:** test_null_email_profile → FAIL (confirmed bug)
+**GREEN:** Added optional chaining in getDisplayName() → PASS
+**DIFF:** 43 pass | 0 fail | 2 skipped (zero new failures)
+**SCAN:** 2 sibling locations with same pattern → proposed batch fix
+
+### Quality Gates
+lint OK | typecheck OK | build OK | test OK
+
+Next: Run `done` to validate, retro, and archive.
+```

--- a/workflow/references/templates/fix-output.md
+++ b/workflow/references/templates/fix-output.md
@@ -11,7 +11,7 @@ Edit this file to customize what the agent returns after `fix`. Decision logic: 
 
 **Bug:** {description}
 **Root cause:** {1-line cause}
-**Classification:** simple | complex
+**Classification:** simple | complex | highly complex
 **Fix:** {1-line what changed}
 
 ### Anti-Cascade TDD
@@ -60,7 +60,38 @@ When DIFF detects regressions:
 **Regressions:**
 - {test name}: {what broke}
 
+**Rollback cycle:** {N}/3
 Options: fix regressions (keep original fix) | roll back (different approach) | escalate
+```
+
+---
+
+## Fix Escalated
+
+When investigation is exhausted or rollback cap (3) reached:
+
+```markdown
+## Fix Escalated
+
+**Bug:** {description}
+**Classification:** {complex/highly complex}
+**Reason:** {investigation exhausted | rollback cap reached}
+
+### Evidence Collected
+**Hypotheses tested:** {N}
+**Eliminated:** {list with reasons}
+**Rollback attempts:** {N}/3 (if applicable)
+
+### What We Know
+- {confirmed fact 1}
+- {confirmed fact 2}
+
+### What's Unknown
+- {remaining uncertainty}
+
+### Recommended Next Steps
+1. {suggestion — e.g., add instrumentation, pair debug, domain expert}
+2. {alternative — e.g., defer, accept risk, workaround}
 ```
 
 ---

--- a/workflow/references/templates/fix-output.md
+++ b/workflow/references/templates/fix-output.md
@@ -20,13 +20,13 @@ Edit this file to customize what the agent returns after `fix`. Decision logic: 
 **GREEN:** {what changed} → PASS
 **DIFF:** {N} pass | {N} fail | {N} skipped (zero new failures)
 **SCAN:** {N} sibling locations | {proposed/none found}
-**PREVENT:** {N} rules proposed | {approved/declined/skipped}
+
+### Learning
+**Spec:** {spec name} updated | N/A (no active spec)
+**Rules:** {N} proposed → {approved/declined/skipped} → target: {agent config file}
 
 ### Quality Gates
 lint {OK/FAIL} | typecheck {OK/FAIL} | build {OK/FAIL} | test {OK/FAIL}
-
-{If spec updated:}
-**Spec:** {spec name} updated with fix status
 
 Next: Run `done` to validate, retro, and archive.
 ```
@@ -101,9 +101,12 @@ Next: Run `done` to validate, retro, and archive.
 **GREEN:** Added optional chaining in getDisplayName() → PASS
 **DIFF:** 43 pass | 0 fail | 2 skipped (zero new failures)
 **SCAN:** 2 sibling locations with same pattern → proposed batch fix
-**PREVENT:** 1 rule proposed → approved
 
-  [{project config} § Coding Rules] rule: "Always null-check optional user fields (email, phone, avatar) before access"
+### Learning
+**Spec:** N/A (no active spec)
+**Rules:** 1 proposed → approved → target: {project}/CLAUDE.md
+
+  [{project}/CLAUDE.md § Coding Rules] rule: "Always null-check optional user fields (email, phone, avatar) before access"
   _Prevents: null reference errors on incomplete user profiles_
 
 ### Quality Gates

--- a/workflow/references/templates/fix-output.md
+++ b/workflow/references/templates/fix-output.md
@@ -20,9 +20,13 @@ Edit this file to customize what the agent returns after `fix`. Decision logic: 
 **GREEN:** {what changed} → PASS
 **DIFF:** {N} pass | {N} fail | {N} skipped (zero new failures)
 **SCAN:** {N} sibling locations | {proposed/none found}
+**PREVENT:** {N} rules proposed | {approved/declined/skipped}
 
 ### Quality Gates
 lint {OK/FAIL} | typecheck {OK/FAIL} | build {OK/FAIL} | test {OK/FAIL}
+
+{If spec updated:}
+**Spec:** {spec name} updated with fix status
 
 Next: Run `done` to validate, retro, and archive.
 ```
@@ -97,6 +101,10 @@ Next: Run `done` to validate, retro, and archive.
 **GREEN:** Added optional chaining in getDisplayName() → PASS
 **DIFF:** 43 pass | 0 fail | 2 skipped (zero new failures)
 **SCAN:** 2 sibling locations with same pattern → proposed batch fix
+**PREVENT:** 1 rule proposed → approved
+
+  [{project config} § Coding Rules] rule: "Always null-check optional user fields (email, phone, avatar) before access"
+  _Prevents: null reference errors on incomplete user profiles_
 
 ### Quality Gates
 lint OK | typecheck OK | build OK | test OK


### PR DESCRIPTION
## Summary

- Extracts bug fix mode from `ship.md` into a dedicated `fix` action
- `fix` has its own lifecycle: investigate (scientific debugging) → fix (anti-cascade TDD) → validate
- `ship` is now pure feature mode — no bug-specific branching
- New router entry: `"fix", "debug", "repair"` → `fix.md`

## New files

| File | Purpose |
|------|---------|
| `references/actions/fix.md` | 3-phase bug fix action (classify → investigate → TDD → validate) |
| `references/templates/fix-output.md` | Output templates: complete, complex, blocked, abbreviated, example |

## Modified files

| File | Change |
|------|--------|
| `SKILL.md` | 10 commands, fix in router/triggers/references, v1.2 |
| `ship.md` | Remove bug mode detection, anti-cascade TDD, bug tasks, bug ACs. Add pointer to fix.md. Update Bug Encounter Protocol to hand off to fix. |
| `session-management.md` | Mention fix action, add fix-mode resume note |
| `README.md` | Add fix to workflow command list |

## Design decisions

- **fix is peer to ship** — own action file, own output template, own router entry
- **Bug Encounter Protocol stays in ship.md** — bugs found DURING feature work hand off to fix
- **Same quality gates, session management, done.md** — no duplication
- **Shared patterns unchanged** — debugging.md and regression-testing.md stay as references

## Test plan

- [ ] Trace: "fix the login bug" → router → fix.md → debugging.md → regression-testing.md → fix-output.md → done.md
- [ ] Trace: "ship the feature" → router → ship.md (no bug content) → ship-output.md (no bug conditionals)
- [ ] Verify ship.md Bug Encounter Protocol hands off to fix action
- [ ] Cross-references: SKILL.md ↔ fix.md ↔ ship.md ↔ session-management.md