### PR TITLE
feat(workflow,analyze): integrate codebase-intelligence CLI for TypeScript repos

### DIFF
--- a/analyze/SKILL.md
+++ b/analyze/SKILL.md
@@ -16,6 +16,16 @@ Use when:
 
 Triggers: "analyze", "key points", "what's important", "improve this", "review", "examine", "assess", "analysis", "deep analysis", "run deep analysis", "brief", "challenge assumptions", "first principles"
 
+## Agent Capabilities
+
+| Capability | Used For | Required | Fallback |
+|------------|----------|----------|----------|
+| File read | Load target files/folders | Yes | — |
+| Sub-agent dispatch | Parallel perspective analysis | Recommended | Sequential in main thread |
+| Codebase intelligence (`npx codebase-intelligence`) | Structural analysis for TS/TSX software domain | No | Pure reasoning from file contents |
+
+This skill remains fully functional without CLI tools. Codebase intelligence is an optional enhancement for the software domain only.
+
 ---
 
 ## Table of Contents
@@ -66,9 +76,18 @@ analyze thorough "migration to microservices"
 1. **Mode**: Detect from keywords (quick/standard/deep)
 2. **Domain**: Auto-detect from content/keywords
 3. **Target**: Load file/folder content if path provided
+4. **TypeScript detection**: If target is a code path and `tsconfig.json` exists:
+   - Run CI detection gate (see `../../workflow/references/codebase-intelligence.md`)
+   - If available: gather structural data in Phase 1
+   - If unavailable: proceed with pure file-reading context gathering
 
 ### Phase 1: Context Gathering
 - **File/folder path** → Read files
+- **Software domain + TypeScript + CI available** → Augment file reading with:
+  - `npx codebase-intelligence overview --json <path>` → project structure snapshot
+  - `npx codebase-intelligence modules --json <path>` → module boundaries and cross-deps
+  - `npx codebase-intelligence groups --json <path>` → directory-level aggregates
+  Include as structured context alongside file contents. If CI unavailable: read files only.
 - **Topic/idea** → Use provided context
 - **Unfamiliar domain** → Optional web search
 
@@ -86,6 +105,16 @@ Direct analysis by primary agent, no sub-agents
 1. Select 6-10 perspectives based on domain
 2. Launch all perspectives in parallel (single message block)
 3. Each agent answers 12 questions (7 core + 5 deep)
+
+#### Software Domain Enhancement (TypeScript + CI available)
+
+Include pre-computed structural data in software domain agent prompts:
+- `npx codebase-intelligence hotspots --json --metric complexity --limit 20` → complexity/churn hotspots
+- `npx codebase-intelligence forces --json` → cohesion/coupling tensions per module
+- `npx codebase-intelligence dead-exports --json --limit 20` → unused export analysis
+- `npx codebase-intelligence clusters --json` → dependency community clusters
+
+Agents receive this as structured context alongside the target content. Supplements their analysis — does not replace independent reasoning. If CI unavailable: agents analyze from file contents only.
 
 ### Phase 3: Synthesis
 After ALL agents complete:
@@ -593,6 +622,8 @@ This skill is **standalone** and includes all necessary frameworks:
 - Output formats (embedded)
 
 No external dependencies required.
+
+**Optional enhancement:** For software domain analysis of TypeScript codebases, `codebase-intelligence` CLI (`npx codebase-intelligence`) provides structural data — hotspots, coupling, dead exports, module boundaries, blast radius. See `../../workflow/references/codebase-intelligence.md` for command reference. The skill works identically without it — data is supplementary context for perspective agents.
 
 ---
 

--- a/analyze/SKILL.md
+++ b/analyze/SKILL.md
@@ -77,7 +77,8 @@ analyze thorough "migration to microservices"
 2. **Domain**: Auto-detect from content/keywords
 3. **Target**: Load file/folder content if path provided
 4. **TypeScript detection**: If target is a code path and `tsconfig.json` exists:
-   - Run CI detection gate (see `../../workflow/references/codebase-intelligence.md`)
+   - Detection gate: `tsconfig.json` exists + `npx codebase-intelligence --help` succeeds
+   - For full CLI reference, fetch `https://raw.githubusercontent.com/bntvllnt/codebase-intelligence/main/llms.txt`
    - If available: gather structural data in Phase 1
    - If unavailable: proceed with pure file-reading context gathering
 
@@ -623,7 +624,7 @@ This skill is **standalone** and includes all necessary frameworks:
 
 No external dependencies required.
 
-**Optional enhancement:** For software domain analysis of TypeScript codebases, `codebase-intelligence` CLI (`npx codebase-intelligence`) provides structural data — hotspots, coupling, dead exports, module boundaries, blast radius. See `../../workflow/references/codebase-intelligence.md` for command reference. The skill works identically without it — data is supplementary context for perspective agents.
+**Optional enhancement:** For software domain analysis of TypeScript codebases, `codebase-intelligence` CLI (`npx codebase-intelligence --json`) provides structural data — hotspots, coupling, dead exports, module boundaries, blast radius. Detection: `tsconfig.json` must exist. For full CLI reference, fetch `https://raw.githubusercontent.com/bntvllnt/codebase-intelligence/main/llms-full.txt`. The skill works identically without it — data is supplementary context for perspective agents.
 
 ---
 

--- a/workflow/SKILL.md
+++ b/workflow/SKILL.md
@@ -26,6 +26,7 @@ High-velocity solo development. Idea to production same-day.
 | File read/write | Specs, config, history | Yes | — |
 | Code search (grep/glob) | Discovery, context | Yes | — |
 | Shell/command execution | Quality gates (lint, build, test) | Yes | List commands for user to run |
+| Codebase intelligence (`npx codebase-intelligence`) | Structural analysis for TS/TSX projects (graph, metrics, blast radius) | No | grep/glob/read (manual exploration) |
 | Task/todo tracking | Phase management | Recommended | Track in spec Progress section |
 | User interaction | Stuck escalation, risk flags | Recommended | Log decisions in spec Notes |
 | Web/doc search | Pattern lookup | No | Use embedded patterns |
@@ -164,7 +165,7 @@ Review standards:
 - [Production Standards](references/reviews/production-standards.md)
 
 Specs & gates:
-- [Spec template](references/spec-template.md) | [Quality gates](references/quality-gates.md) | [Session management](references/session-management.md) | [Memory update](references/memory-update.md) | [Testing automation](references/testing-automation.md) | [E2E scenarios](references/e2e-scenarios.md)
+- [Spec template](references/spec-template.md) | [Quality gates](references/quality-gates.md) | [Session management](references/session-management.md) | [Memory update](references/memory-update.md) | [Testing automation](references/testing-automation.md) | [E2E scenarios](references/e2e-scenarios.md) | [Codebase intelligence](references/codebase-intelligence.md)
 
 Patterns:
 - [Implementation](references/patterns/implementation.md) | [Planning](references/patterns/planning.md) | [Debugging](references/patterns/debugging.md) | [Decisions](references/patterns/decisions.md) | [Decomposition](references/patterns/decomposition.md) | [Regression testing](references/patterns/regression-testing.md)

--- a/workflow/references/actions/fix.md
+++ b/workflow/references/actions/fix.md
@@ -81,11 +81,34 @@ Each hypothesis must:
   - State what evidence would CONFIRM vs ELIMINATE it
 ```
 
+**TypeScript projects with CI available** (augments code reading):
+
+```
+For suspect function/symbol:
+  npx codebase-intelligence symbol --json <path> <name>
+    → Callers, callees, type info — narrows hypothesis scope
+  npx codebase-intelligence dependents --json <file>
+    → Blast radius — what else could be affected by this bug?
+If CI unavailable: use grep for callers/callees
+See references/codebase-intelligence.md for full command reference.
+```
+
 ### Step 3: TEST HYPOTHESES
 
 For **complex** bugs: test each hypothesis sequentially, highest probability first.
 
 For **highly complex** bugs: if the agent supports parallel execution (sub-agents, concurrent tool calls, or background tasks), investigate multiple hypotheses simultaneously. If not, investigate sequentially but assign a time box per hypothesis to avoid rabbit holes.
+
+**TypeScript structural investigation** (if CI available):
+
+```
+npx codebase-intelligence processes --json <path>
+  → Entry-point execution tracing — identifies code paths through suspect area
+npx codebase-intelligence impact --json <path> <symbol>
+  → Symbol-level blast radius — what breaks if this symbol behaves differently?
+Feed these to investigation agents alongside hypothesis prompts.
+If CI unavailable: agents use grep + manual code path tracing.
+```
 
 #### Highly Complex: Parallel Investigation
 

--- a/workflow/references/actions/focus.md
+++ b/workflow/references/actions/focus.md
@@ -45,6 +45,18 @@ Also estimate codebase size:
 
 Count source files only (exclude `node_modules`, `dist`, `.git`, lockfiles, generated).
 
+### TypeScript Structural Snapshot (Optional)
+
+If TypeScript detected (`tsconfig.json` exists):
+
+```
+Load references/codebase-intelligence.md for detection gate.
+Run: npx codebase-intelligence overview --json <project-root>
+  → Accurate file/module count (replaces manual estimation)
+  → Dependency graph shape informs agent count decision
+If CI unavailable: use file count estimation above
+```
+
 ---
 
 ## Step 1: Scan Existing Specs
@@ -148,6 +160,14 @@ Instructions:
 4. For each finding, propose a CONCRETE TASK (not an observation):
    - BAD: "Missing error handling detected"
    - GOOD: "Add error handling to database queries in src/db/users.ts"
+{if TypeScript project with CI available, add to each agent prompt:}
+5b. Use these pre-computed structural insights (from codebase-intelligence --json):
+   - HOTSPOTS: {output of `npx codebase-intelligence hotspots --json --metric complexity --limit 20`}
+   - DEAD EXPORTS: {output of `npx codebase-intelligence dead-exports --json --limit 20`}
+   - FORCES: {output of `npx codebase-intelligence forces --json`}
+   - MODULES: {output of `npx codebase-intelligence modules --json`}
+   Cross-reference these with your Glob/Grep/Read findings.
+   Hotspots data replaces sampling strategy for TypeScript files.
 5. Score each task:
    - Impact: H (affects users/security/data) / M (affects DX/maintainability) / L (cosmetic/minor)
    - Effort: L (<1h) / M (1-4h) / H (4h+)
@@ -172,6 +192,8 @@ For 500+ source files, agents should focus on:
 3. Critical paths (auth, payments, data mutations)
 4. Files with TODOs/FIXMEs/HACKs
 5. Files without test coverage (look for missing `*.test.*` counterparts)
+
+**TypeScript projects with CI:** `hotspots` data from codebase-intelligence replaces sampling heuristics for TS/TSX files. Non-TS files in the same project still use the sampling strategy above.
 
 ---
 

--- a/workflow/references/actions/plan.md
+++ b/workflow/references/actions/plan.md
@@ -47,6 +47,18 @@ Deep test discovery (feeds spec Test Strategy):
   - If no E2E infra but unit tests exist: flag "partial — E2E setup needed at ship"
 ```
 
+### TypeScript Structural Analysis (Optional)
+
+If TypeScript detected (`tsconfig.json` exists):
+
+```
+Load references/codebase-intelligence.md for detection gate and command reference.
+Run: npx codebase-intelligence overview --json <project-root>
+  → Captures: file count, module count, dependency graph shape, top-level metrics
+  → Store as "CI Snapshot" for Codebase Impact section
+If CI unavailable: skip — grep/glob/read discovery continues as normal
+```
+
 ## Step 1: Parse Idea
 
 Extract from user input:
@@ -73,6 +85,20 @@ Extract from user input:
 - Validation rules
 
 Key principle: **Read the codebase BEFORE writing the spec.** Codebase impact analysis is MANDATORY and informs every section that follows.
+
+**TypeScript projects with CI available** (augments grep/glob/read, does not replace):
+
+```
+For each file identified in Codebase Impact table:
+  npx codebase-intelligence file --json <file>
+    → Adds: imports, exports, coupling score, complexity
+  npx codebase-intelligence dependents --json <file>
+    → Adds: files affected by changes → populates AFFECTED rows
+For key symbols being changed:
+  npx codebase-intelligence impact --json <symbol>
+    → Adds: blast radius data for Breaking Changes assessment
+If CI unavailable: use grep for imports/exports, manual trace for dependents
+```
 
 Create spec file at `specs/active/{YYYY-MM-DD}-{slug}.md`.
 

--- a/workflow/references/actions/review.md
+++ b/workflow/references/actions/review.md
@@ -18,6 +18,11 @@ Before any review, build a change map:
    - Risk: HIGH | MEDIUM | LOW
 3. Detect primary language + framework from changed files
 4. Detect context signals (see Step 2)
+5. **TypeScript structural risk** (if CI available, see `references/codebase-intelligence.md`):
+   Run: `npx codebase-intelligence changes --json`
+   → Augments git diff with coupling score, blast radius, and complexity delta per file
+   → Use to refine Risk Classification below (more precise than filename-based heuristics)
+   If CI unavailable: use filename-based risk classification only
 ```
 
 ### Risk Classification
@@ -91,6 +96,21 @@ Example: `Review mode: Deep — HIGH risk file detected (src/api/auth.ts: auth/s
 | Observability | Production service, background job, API endpoint, webhook handler |
 | Testability | Complex branching (>=3 paths), critical business logic, stateful flows |
 | Accessibility | UI components, forms, navigation, interactive elements |
+
+### Structural Context (TypeScript projects with CI)
+
+Before dispatching perspective agents in Standard/Deep/Production modes, gather structural data:
+
+```
+For each changed TS/TSX file:
+  npx codebase-intelligence dependents --json <file>
+    → Consumer awareness: who imports this? What could break?
+  npx codebase-intelligence forces --json
+    → Cohesion/coupling metrics for architectural review
+
+Include in perspective agent context alongside file contents and diff.
+If CI unavailable: perspectives rely on file contents + grep-based import tracing.
+```
 
 ### Deep Mode
 

--- a/workflow/references/actions/ship.md
+++ b/workflow/references/actions/ship.md
@@ -39,6 +39,11 @@ Update tasks as you work: mark in-progress when starting, complete when done. On
 ## Phase 0: Setup
 
 1. **Detect project stack** (monorepo, framework, test runner, linter, E2E framework)
+1b. **TypeScript structural analysis** (if `tsconfig.json` detected):
+    Load `references/codebase-intelligence.md`, run detection gate.
+    Run: `npx codebase-intelligence overview --json <project-root>`
+    → Augments stack detection with module structure, dependency graph, file metrics.
+    If CI unavailable: proceed with standard stack detection only.
 2. **Validate test environment:**
    - Load spec's Test Strategy (from plan phase, if exists)
    - If no Test Strategy: run test setup discovery now (load references/testing-automation.md)
@@ -72,6 +77,10 @@ For quick fixes and small features without an active spec:
 
 ```
 1. Analyze scope (files affected, estimated LOC)
+1b. **TypeScript scope analysis** (if CI available):
+    `npx codebase-intelligence dependents --json <file>` for each affected file → reveals non-obvious consumers.
+    For refactoring: `npx codebase-intelligence rename --json <path> <symbol>` → discovers all references before changes.
+    If CI unavailable: use grep for scope analysis.
 2. Run test setup discovery (load references/testing-automation.md)
 3. Create plan (brief, inline)
 4. Write E2E test for key behavior (RED — MUST FAIL)

--- a/workflow/references/codebase-intelligence.md
+++ b/workflow/references/codebase-intelligence.md
@@ -1,0 +1,113 @@
+# Codebase Intelligence (TypeScript Structural Analysis)
+
+> **Agent:** Load this file when working with a TypeScript codebase. Provides graph-based structural analysis via CLI.
+
+**Method:** CLI via `npx`. TypeScript codebases only.
+
+---
+
+## Detection Gate
+
+Before using any command, verify both conditions:
+
+```
+1. tsconfig.json exists at project root (or nearest parent)
+   → If missing: NOT a TypeScript project — skip all CI commands
+2. npx codebase-intelligence --help exits successfully
+   → If fails: CI not available — fall back to grep/glob/read
+```
+
+Cache detection result per session. Do not re-check on every command.
+
+---
+
+## Invocation Pattern
+
+```bash
+npx codebase-intelligence <command> --json <path> [flags]
+```
+
+Always use `--json` for machine-readable output. Timeout: 30s per command. Non-zero exit or timeout = silent fallback to grep/glob/read.
+
+---
+
+## Commands
+
+### Discovery
+
+| Command | Purpose | Example | Fallback |
+|---------|---------|---------|----------|
+| `overview` | Codebase snapshot: file count, module count, graph shape, top metrics | `npx codebase-intelligence overview --json ./src` | `find` + manual counting |
+| `modules` | Module structure and cross-dependencies | `npx codebase-intelligence modules --json ./src` | Grep for import paths |
+| `groups` | Top-level directory aggregates with metrics | `npx codebase-intelligence groups --json ./src` | `ls` + manual inspection |
+| `clusters` | Louvain community detection — file groupings | `npx codebase-intelligence clusters --json ./src` | Manual folder analysis |
+| `search` | BM25 keyword search across codebase | `npx codebase-intelligence search --json ./src "query"` | `grep` / Grep tool |
+
+### Analysis
+
+| Command | Purpose | Example | Fallback |
+|---------|---------|---------|----------|
+| `hotspots` | Rank files by architectural metric | `npx codebase-intelligence hotspots --json ./src --metric complexity --limit 10` | Manual code review |
+| `forces` | Cohesion/tension analysis per module | `npx codebase-intelligence forces --json ./src` | Manual architecture review |
+| `dead-exports` | Unused exports safe for removal | `npx codebase-intelligence dead-exports --json ./src --limit 20` | Grep for unused exports |
+| `file` | Detailed context for a single file: imports, exports, coupling, complexity | `npx codebase-intelligence file --json ./src/index.ts` | Read + manual analysis |
+| `changes` | Git diff analysis with risk assessment (coupling, blast radius, complexity delta) | `npx codebase-intelligence changes --json ./src` | `git diff` + manual risk classification |
+
+### Impact & Tracing
+
+| Command | Purpose | Example | Fallback |
+|---------|---------|---------|----------|
+| `dependents` | File-level blast radius — who imports this file? | `npx codebase-intelligence dependents --json ./src/utils.ts` | Grep for import references |
+| `symbol` | Callers/callees for a specific function or export | `npx codebase-intelligence symbol --json ./src functionName` | Grep for function references |
+| `impact` | Symbol-level transitive blast radius | `npx codebase-intelligence impact --json ./src parseCodebase` | Manual call chain tracing |
+| `processes` | Entry-point execution flow tracing | `npx codebase-intelligence processes --json ./src` | Manual code path tracing |
+| `rename` | Discover all references for safe refactoring | `npx codebase-intelligence rename --json ./src oldName` | Grep + find-replace |
+
+---
+
+## Flags
+
+| Flag | Applies To | Description |
+|------|-----------|-------------|
+| `--json` | All commands | Machine-readable JSON output (ALWAYS use) |
+| `--force` | All commands | Rebuild cache even if valid |
+| `--limit <n>` | hotspots, dead-exports, others | Restrict result count |
+| `--metric <m>` | hotspots | Select ranking metric (see below) |
+
+---
+
+## Metrics (for `--metric` flag)
+
+| Metric | What It Measures |
+|--------|-----------------|
+| `pagerank` | Most-referenced files by graph importance |
+| `betweenness` | Bridge files connecting disconnected modules |
+| `coupling` | File entanglement (fan-out ratio) |
+| `cohesion` | Module internal cohesiveness |
+| `tension` | Files pulled across modules (entropy-based) |
+| `churn` | Git commit frequency |
+| `complexity` | Average cyclomatic complexity of exports |
+| `blast-radius` | Transitive dependents affected by change |
+| `dead-exports` | Unused exports safe for removal |
+| `coverage` | Test file existence per source file |
+| `escape-velocity` | Module should become its own package |
+
+---
+
+## Cache
+
+- Auto-stored in `.code-visualizer/` directory at project root
+- Use `--force` to rebuild after significant structural changes
+- Recommend adding `.code-visualizer/` to `.gitignore`
+
+---
+
+## Error Handling
+
+```
+Command fails or times out (30s)?
+  → Log silently, fall back to grep/glob/read equivalent
+  → Never surface CI errors to user
+  → Never block workflow on CI availability
+```
+

--- a/workflow/references/codebase-intelligence.md
+++ b/workflow/references/codebase-intelligence.md
@@ -6,6 +6,19 @@
 
 ---
 
+## Documentation (Single Source of Truth)
+
+Command reference, flags, metrics, data model, and tool selection guide live in the upstream repo — not here. Fetch the appropriate doc before first use:
+
+| Doc | URL | When to Use |
+|-----|-----|-------------|
+| **llms.txt** (summary) | `https://raw.githubusercontent.com/bntvllnt/codebase-intelligence/main/llms.txt` | Quick orientation — commands, capabilities, tool selection |
+| **llms-full.txt** (complete) | `https://raw.githubusercontent.com/bntvllnt/codebase-intelligence/main/llms-full.txt` | Full reference — architecture, data model, metrics, all CLI syntax, flags |
+
+**Fetch once per session** using WebFetch or `curl`. These files are always up-to-date with the latest release.
+
+---
+
 ## Detection Gate
 
 Before using any command, verify both conditions:
@@ -24,73 +37,56 @@ Cache detection result per session. Do not re-check on every command.
 ## Invocation Pattern
 
 ```bash
-npx codebase-intelligence <command> --json <path> [flags]
+npx codebase-intelligence <command> <path> [flags] --json
 ```
 
 Always use `--json` for machine-readable output. Timeout: 30s per command. Non-zero exit or timeout = silent fallback to grep/glob/read.
 
 ---
 
-## Commands
+## Quick Reference (Common Workflows)
 
-### Discovery
+For full command syntax and flags, see `llms-full.txt` above.
 
-| Command | Purpose | Example | Fallback |
-|---------|---------|---------|----------|
-| `overview` | Codebase snapshot: file count, module count, graph shape, top metrics | `npx codebase-intelligence overview --json ./src` | `find` + manual counting |
-| `modules` | Module structure and cross-dependencies | `npx codebase-intelligence modules --json ./src` | Grep for import paths |
-| `groups` | Top-level directory aggregates with metrics | `npx codebase-intelligence groups --json ./src` | `ls` + manual inspection |
-| `clusters` | Louvain community detection — file groupings | `npx codebase-intelligence clusters --json ./src` | Manual folder analysis |
-| `search` | BM25 keyword search across codebase | `npx codebase-intelligence search --json ./src "query"` | `grep` / Grep tool |
-
-### Analysis
-
-| Command | Purpose | Example | Fallback |
-|---------|---------|---------|----------|
-| `hotspots` | Rank files by architectural metric | `npx codebase-intelligence hotspots --json ./src --metric complexity --limit 10` | Manual code review |
-| `forces` | Cohesion/tension analysis per module | `npx codebase-intelligence forces --json ./src` | Manual architecture review |
-| `dead-exports` | Unused exports safe for removal | `npx codebase-intelligence dead-exports --json ./src --limit 20` | Grep for unused exports |
-| `file` | Detailed context for a single file: imports, exports, coupling, complexity | `npx codebase-intelligence file --json ./src/index.ts` | Read + manual analysis |
-| `changes` | Git diff analysis with risk assessment (coupling, blast radius, complexity delta) | `npx codebase-intelligence changes --json ./src` | `git diff` + manual risk classification |
-
-### Impact & Tracing
-
-| Command | Purpose | Example | Fallback |
-|---------|---------|---------|----------|
-| `dependents` | File-level blast radius — who imports this file? | `npx codebase-intelligence dependents --json ./src/utils.ts` | Grep for import references |
-| `symbol` | Callers/callees for a specific function or export | `npx codebase-intelligence symbol --json ./src functionName` | Grep for function references |
-| `impact` | Symbol-level transitive blast radius | `npx codebase-intelligence impact --json ./src parseCodebase` | Manual call chain tracing |
-| `processes` | Entry-point execution flow tracing | `npx codebase-intelligence processes --json ./src` | Manual code path tracing |
-| `rename` | Discover all references for safe refactoring | `npx codebase-intelligence rename --json ./src oldName` | Grep + find-replace |
+| Question | Command |
+|----------|---------|
+| What does this codebase look like? | `npx codebase-intelligence overview ./src --json` |
+| What are the riskiest files? | `npx codebase-intelligence hotspots ./src --metric complexity --json` |
+| Tell me about file X | `npx codebase-intelligence file ./src <file> --json` |
+| What breaks if I change file X? | `npx codebase-intelligence dependents ./src <file> --json` |
+| What breaks if I change function X? | `npx codebase-intelligence impact ./src <symbol> --json` |
+| Who calls this function? | `npx codebase-intelligence symbol ./src <name> --json` |
+| What changed + risk? | `npx codebase-intelligence changes ./src --json` |
+| Find unused exports | `npx codebase-intelligence dead-exports ./src --json` |
+| Module architecture | `npx codebase-intelligence modules ./src --json` |
+| Architectural tensions | `npx codebase-intelligence forces ./src --json` |
+| Find all references for rename | `npx codebase-intelligence rename ./src <oldName> <newName> --json` |
+| Execution flow tracing | `npx codebase-intelligence processes ./src --json` |
+| File community clusters | `npx codebase-intelligence clusters ./src --json` |
 
 ---
 
-## Flags
+## Fallback (When CI Unavailable)
 
-| Flag | Applies To | Description |
-|------|-----------|-------------|
-| `--json` | All commands | Machine-readable JSON output (ALWAYS use) |
-| `--force` | All commands | Rebuild cache even if valid |
-| `--limit <n>` | hotspots, dead-exports, others | Restrict result count |
-| `--metric <m>` | hotspots | Select ranking metric (see below) |
+Every CI command has a grep/glob/read equivalent. If CI is unavailable or fails, fall back silently:
 
----
-
-## Metrics (for `--metric` flag)
-
-| Metric | What It Measures |
-|--------|-----------------|
-| `pagerank` | Most-referenced files by graph importance |
-| `betweenness` | Bridge files connecting disconnected modules |
-| `coupling` | File entanglement (fan-out ratio) |
-| `cohesion` | Module internal cohesiveness |
-| `tension` | Files pulled across modules (entropy-based) |
-| `churn` | Git commit frequency |
-| `complexity` | Average cyclomatic complexity of exports |
-| `blast-radius` | Transitive dependents affected by change |
-| `dead-exports` | Unused exports safe for removal |
-| `coverage` | Test file existence per source file |
-| `escape-velocity` | Module should become its own package |
+| CI Command | Fallback |
+|------------|----------|
+| `overview` | `find` + manual file counting |
+| `dependents` | Grep for import references |
+| `symbol` | Grep for function references |
+| `impact` | Manual call chain tracing |
+| `hotspots` | Manual code review |
+| `changes` | `git diff` + manual risk classification |
+| `file` | Read + manual analysis |
+| `forces` | Manual architecture review |
+| `dead-exports` | Grep for unused exports |
+| `modules` | Grep for import paths |
+| `rename` | Grep + find-replace |
+| `processes` | Manual code path tracing |
+| `clusters` | Manual folder analysis |
+| `groups` | `ls` + manual inspection |
+| `search` | Grep tool |
 
 ---
 
@@ -110,4 +106,3 @@ Command fails or times out (30s)?
   → Never surface CI errors to user
   → Never block workflow on CI availability
 ```
-

--- a/workflow/references/spec-template.md
+++ b/workflow/references/spec-template.md
@@ -81,6 +81,11 @@ Each section below shows: the template (what goes in the spec) then the generati
 **Generation rules:**
 - **MANDATORY: Read the codebase before writing anything else.**
 - Search for related code: grep keywords, read affected files, check existing patterns
+- **TypeScript projects (if CI available):** Augment manual discovery with structural data:
+  - `npx codebase-intelligence dependents --json <file>` for each MODIFY file → populates AFFECTED rows
+  - `npx codebase-intelligence impact --json <symbol>` for changed exports → validates blast radius
+  - `npx codebase-intelligence file --json <file>` for detailed file context → informs Reuse field
+  - See `references/codebase-intelligence.md` for full command reference and fallback protocol
 - Map every file that will be created, modified, or indirectly affected
 - Identify code to reuse — never reinvent what exists
 - Flag breaking changes to exports, APIs, schemas, config


### PR DESCRIPTION
## Summary

- Add `npx codebase-intelligence` as optional structural analysis tool for TypeScript codebases across workflow and analyze skills
- Create shared reference doc (`workflow/references/codebase-intelligence.md`) with detection gate, all 15 CLI commands, fallback protocol, and MCP alternative note
- Integrate into 6 workflow actions (plan, focus, review, fix, ship) + spec-template + analyze skill
- All gated behind `tsconfig.json` detection with graceful fallback to grep/glob/read — zero impact on non-TS projects

## Changes

| File | What |
|------|------|
| `workflow/references/codebase-intelligence.md` | **NEW** — shared reference: detection gate, 15 commands, flags, metrics, fallbacks, MCP note |
| `workflow/SKILL.md` | +capabilities table row, +reference link |
| `workflow/references/actions/plan.md` | Step 0: `overview` snapshot. Step 3: `dependents`/`file`/`impact` for Codebase Impact |
| `workflow/references/spec-template.md` | CI-powered Codebase Impact generation rules |
| `workflow/references/actions/focus.md` | `overview` for sizing, `hotspots`/`forces`/`modules`/`dead-exports` in agent prompts |
| `workflow/references/actions/review.md` | `changes` for risk assessment, `dependents`/`forces` for structural context |
| `workflow/references/actions/fix.md` | `symbol` for callers/callees, `processes`/`impact` for tracing |
| `workflow/references/actions/ship.md` | `overview` for stack detection, `rename`/`dependents` for scope analysis |
| `analyze/SKILL.md` | Capabilities table, Phase 0/1/2 augmentations, integration notes |

## Design Principles

- **Augment, never replace** — every CI block includes fallback to existing grep/glob/read
- **CLI preferred over MCP** — `npx` works universally across agents
- **`--json` always** — machine-readable output for agent parsing
- **Graceful degradation** — non-zero exit or timeout = silent fallback, never blocks workflow

## Test plan

- [ ] Verify `tsconfig.json` detection gates all CI commands (non-TS project = no CI invocations)
- [ ] Verify every `npx codebase-intelligence` call uses `--json` flag
- [ ] Verify every integration point has "If CI unavailable:" fallback
- [ ] Test `plan`, `focus`, `review` actions in a real TypeScript repo