### PR TITLE
feat(workflow): define runtime-neutral line-by-line review spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [1.13.1] - 2026-04-17
 
 - feat(workflow): require line-by-line change coverage and rule-by-rule rules enforcement in review mode
-- docs(workflow): define a core portable review spec plus optional executor patterns for OSS-safe review portability
+- docs(workflow): define a runtime-neutral portable review spec plus optional executor patterns for OSS-safe review portability
 
 ## [1.13.0] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.13.1] - 2026-04-17
+
+- feat(workflow): require line-by-line change coverage and rule-by-rule rules enforcement in review mode
+- docs(workflow): add review coverage summary format and rules discovery protocol
+
 ## [1.13.0] - 2026-04-15
 
 - feat(oss-readiness): add harness-agnostic OSS/public release skill with audit, CI, llms, and scaffolding flows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [1.13.1] - 2026-04-17
 
 - feat(workflow): require line-by-line change coverage and rule-by-rule rules enforcement in review mode
-- docs(workflow): add review coverage summary format and rules discovery protocol
+- docs(workflow): define a core portable review spec plus optional executor patterns for OSS-safe review portability
 
 ## [1.13.0] - 2026-04-15
 

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -33,7 +33,7 @@ No flags needed — the agent auto-detects intent from your natural language (e.
 The `review` command is defined as a **core portable review spec**:
 - the core contract defines what review must cover and what evidence it must emit
 - executors are optional implementation patterns that can be single-agent, multi-agent, CI, or human/manual
-- the workflow skill should stay model-agnostic and harness-agnostic in open source
+- the workflow skill should stay runtime-neutral in open source
 
 See:
 - `references/reviews/core-portable-review-spec.md`

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -20,7 +20,7 @@ npx skills add bntvllnt/agent-skills --skill workflow -g
 | `plan {idea}` | Create spec with user journey, ACs, scope |
 | `spike {question}` | Time-boxed exploration, produces go/no-go |
 | `ship` or `ship {idea}` | Implement with build/review/fix loop |
-| `review` | Multi-perspective code review (5-9 perspectives) |
+| `review` | Multi-perspective code review with line-by-line + rule-by-rule coverage |
 | `focus` | Scan codebase, prioritize tasks toward production readiness |
 | `done` | Validate, retro, archive, propose memory update |
 | `drop` | Abandon with learnings preserved |
@@ -102,7 +102,7 @@ Agent: Loading spec... mode: LOOP (3 scope items, max 5 iterations)
          ✓ Created src/routes/auth.ts
          Quick pass: lint ✓ typecheck ✓
          Scope item 2 [x]
-         Running dev review (5 perspectives)...
+         Running dev review (5 core perspectives + Rules when config files exist)...
            Correctness: PASS
            Security: WARN — add rate limiting to login (medium)
            Reliability: PASS
@@ -178,7 +178,7 @@ Agent: Validating...
 │       ├──────────────────▶  Load spec, create tasks                 │
 │                             Iteration 1: middleware ──▶ lint ✓      │
 │                             Iteration 2: config ──────▶ lint ✓      │
-│                                Dev review (5 perspectives)          │
+│                                Dev review (5 core + Rules)          │
 │                             Iteration 3: tests ───────▶ lint ✓      │
 │                             Full pass: lint ✓ types ✓               │
 │                                         build ✓ test ✓              │

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -20,13 +20,24 @@ npx skills add bntvllnt/agent-skills --skill workflow -g
 | `plan {idea}` | Create spec with user journey, ACs, scope |
 | `spike {question}` | Time-boxed exploration, produces go/no-go |
 | `ship` or `ship {idea}` | Implement with build/review/fix loop |
-| `review` | Multi-perspective code review with line-by-line + rule-by-rule coverage |
+| `review` | Portable multi-perspective review spec with line-by-line + rule-by-rule coverage |
 | `focus` | Scan codebase, prioritize tasks toward production readiness |
 | `done` | Validate, retro, archive, propose memory update |
 | `drop` | Abandon with learnings preserved |
 | `workflow` | Show current state, suggest next action |
 
 No flags needed — the agent auto-detects intent from your natural language (e.g., "review the spec", "skip tests", "emergency fix", "production ready").
+
+## Portable review standard
+
+The `review` command is defined as a **core portable review spec**:
+- the core contract defines what review must cover and what evidence it must emit
+- executors are optional implementation patterns that can be single-agent, multi-agent, CI, or human/manual
+- the workflow skill should stay model-agnostic and harness-agnostic in open source
+
+See:
+- `references/reviews/core-portable-review-spec.md`
+- `references/reviews/executor-patterns.md`
 
 ## Quickstart
 

--- a/workflow/SKILL.md
+++ b/workflow/SKILL.md
@@ -41,7 +41,7 @@ High-velocity solo development. Idea to production same-day.
 | `spike {question}` | Time-boxed exploration | [spike.md](references/actions/spike.md) |
 | `ship` / `ship {idea}` | Implement + validate | [ship.md](references/actions/ship.md) |
 | `fix` / `fix {bug}` | Scientific debug + regression fix | [fix.md](references/actions/fix.md) |
-| `review` | Multi-perspective code review with line-by-line + rule-by-rule coverage | [review.md](references/actions/review.md) |
+| `review` | Portable multi-perspective review spec with line-by-line + rule-by-rule coverage | [review.md](references/actions/review.md) |
 | `spec-review` | Adversarial spec analysis | [spec-review.md](references/actions/spec-review.md) |
 | `focus` | Priority analysis + task proposals | [focus.md](references/actions/focus.md) |
 | `done` | Validate + retro + archive | [done.md](references/actions/done.md) |
@@ -162,7 +162,9 @@ Output templates:
 - [Plan + Spec Review](references/templates/plan-output.md) | [Ship](references/templates/ship-output.md) | [Fix](references/templates/fix-output.md) | [Review](references/templates/review-output.md) | [Focus](references/templates/focus-output.md) | [Done](references/templates/done-output.md) | [Drop](references/templates/drop-output.md) | [Spike](references/templates/spike-output.md) | [Status](references/templates/status-output.md)
 
 Review standards:
-- [Production Standards](references/reviews/production-standards.md)
+- [Core portable review spec](references/reviews/core-portable-review-spec.md) | [Executor patterns](references/reviews/executor-patterns.md) | [Production Standards](references/reviews/production-standards.md)
+
+The portable review spec is normative. Executor patterns are optional implementation guidance.
 
 Specs & gates:
 - [Spec template](references/spec-template.md) | [Quality gates](references/quality-gates.md) | [Session management](references/session-management.md) | [Memory update](references/memory-update.md) | [Testing automation](references/testing-automation.md) | [E2E scenarios](references/e2e-scenarios.md) | [Codebase intelligence](references/codebase-intelligence.md)

--- a/workflow/SKILL.md
+++ b/workflow/SKILL.md
@@ -10,7 +10,7 @@ description: |
   "done", "finish", "complete", "drop", "abandon",
   "workflow", "what's next", "whats next", "next step", "what now".
 license: MIT
-compatibility: "Agent-agnostic. Works with Claude Code, OpenCode, Windsurf, Cursor, Codex, Aider, or any agent supporting SKILL.md."
+compatibility: "Agent-agnostic. Works with any agent that can read SKILL.md files and project rule conventions."
 metadata:
   version: "1.2"
 ---

--- a/workflow/SKILL.md
+++ b/workflow/SKILL.md
@@ -41,7 +41,7 @@ High-velocity solo development. Idea to production same-day.
 | `spike {question}` | Time-boxed exploration | [spike.md](references/actions/spike.md) |
 | `ship` / `ship {idea}` | Implement + validate | [ship.md](references/actions/ship.md) |
 | `fix` / `fix {bug}` | Scientific debug + regression fix | [fix.md](references/actions/fix.md) |
-| `review` | Multi-perspective code review | [review.md](references/actions/review.md) |
+| `review` | Multi-perspective code review with line-by-line + rule-by-rule coverage | [review.md](references/actions/review.md) |
 | `spec-review` | Adversarial spec analysis | [spec-review.md](references/actions/spec-review.md) |
 | `focus` | Priority analysis + task proposals | [focus.md](references/actions/focus.md) |
 | `done` | Validate + retro + archive | [done.md](references/actions/done.md) |

--- a/workflow/references/actions/review.md
+++ b/workflow/references/actions/review.md
@@ -1,6 +1,6 @@
 # Review Action
 
-> **Agent:** Load this file when `review` triggers or during ship loop review cycles.
+> **Agent:** Load this file when `review` triggers or during ship loop review cycles. Also load `references/rules-discovery.md` — discovered rules become the Rules perspective checklist.
 
 Auto-selecting multi-perspective code review. Runs during ship loop or standalone.
 
@@ -8,21 +8,53 @@ Auto-selecting multi-perspective code review. Runs during ship loop or standalon
 
 ## Step 1: Change Overview (ALWAYS FIRST)
 
-Before any review, build a change map:
+Before any review, build a change map **and a line-coverage ledger**:
 
 ```
 1. git diff --name-status (vs base branch or last review)
-2. Per file, classify:
+2. git diff --unified=0 --no-color ...
+   → enumerate every changed hunk with exact line ranges
+   → build a ledger per file: added lines, modified lines, deleted lines
+3. Per file, classify:
    - Category: auth/security | API/public | DB/schema | UI/component |
                config/infra | test | docs | internal logic
    - Risk: HIGH | MEDIUM | LOW
-3. Detect primary language + framework from changed files
-4. Detect context signals (see Step 2)
-5. **TypeScript structural risk** (if CI available, see `references/codebase-intelligence.md`):
+4. Detect primary language + framework from changed files
+5. Detect context signals (see Step 2)
+6. **TypeScript structural risk** (if CI available, see `references/codebase-intelligence.md`):
    Run: `npx codebase-intelligence changes --json`
    → Augments git diff with coupling score, blast radius, and complexity delta per file
    → Use to refine Risk Classification below (more precise than filename-based heuristics)
    If CI unavailable: use filename-based risk classification only
+```
+
+### Coverage Contract (MANDATORY)
+
+No sampling. No “looks fine overall.” No skipping low-risk hunks.
+
+For `review`, the agent must prove two kinds of coverage before returning a clean verdict:
+
+1. **Line coverage** — every changed line range in the diff ledger is checked at least once.
+2. **Rule coverage** — every relevant discovered rule is checked one by one against the changed scope.
+
+Minimum enforcement:
+
+```
+For each changed file:
+  For each changed hunk / line range:
+    assign ≥1 perspective owner
+    inspect the exact changed lines, not just surrounding file context
+
+For each relevant discovered rule:
+  check it explicitly against each changed file/hunk it applies to
+  record: PASS | WARN | FAIL | NOT_APPLICABLE
+```
+
+If any changed line range has no explicit review coverage, or any relevant rule is left unchecked, the review must emit a blocking process finding:
+
+```
+{file}:{line or range} — FAIL [Process] Changed lines not explicitly reviewed
+  Fix: Review the uncovered lines and record perspective coverage
 ```
 
 ### Risk Classification
@@ -36,8 +68,8 @@ Before any review, build a change map:
 ### Output: Change Map
 
 ```
-| File | Category | Risk | Language |
-|------|----------|------|----------|
+| File | Changed lines | Category | Risk | Language |
+|------|---------------|----------|------|----------|
 ```
 
 This table appears in the review output (see `references/templates/review-output.md`).
@@ -77,15 +109,23 @@ Example: `Review mode: Deep — HIGH risk file detected (src/api/auth.ts: auth/s
 
 ## Step 3: Execute Review
 
+### Rules Discovery (MANDATORY — Before Perspective Dispatch)
+
+Load `references/rules-discovery.md` and execute Steps 1-4. This discovers project/user agent config files, extracts rules, filters for relevance against the change map, and classifies severity. The discovered rules become the checklist for the Rules perspective (#10).
+
+No config files found or no relevant rules → skip Rules perspective entirely.
+
+**Important:** rules are not satisfied by a global statement like “follow project rules.” The review must check each relevant rule individually and mark it PASS/WARN/FAIL/NOT_APPLICABLE against the changed scope.
+
 ### Quick Mode
 
-- **Perspectives:** Core 5 (Correctness, Security, Reliability, Performance, DX)
+- **Perspectives:** Core 5 + Rules (if rules files exist)
 - **Checklist depth:** 6 items per perspective (key questions below)
 - **Context loaded:** This file only
 
 ### Standard Mode
 
-- **Perspectives:** Core 5 + auto-triggered conditionals
+- **Perspectives:** Core 5 + Rules (if rules files exist) + auto-triggered conditionals
 - **Checklist depth:** 6 items per perspective
 - **Context loaded:** This file only
 - **Conditional triggers:**
@@ -114,13 +154,13 @@ If CI unavailable: perspectives rely on file contents + grep-based import tracin
 
 ### Deep Mode
 
-- **Perspectives:** All 9 active (no conditional skipping)
+- **Perspectives:** All 9 + Rules (if rules files exist)
 - **Checklist depth:** 6 items per perspective
 - **Context loaded:** This file only
 
 ### Production Mode
 
-- **Perspectives:** All 9 active
+- **Perspectives:** All 9 + Rules (if rules files exist; ambiguous rule signals → FAIL)
 - **Checklist depth:** 15-20 items per perspective (extended checklists)
 - **Context loaded:** This file + `references/reviews/production-standards.md`
 - **Additional:** Expert personas, company bar evaluation, language-specific overlay
@@ -159,6 +199,14 @@ If CI unavailable: perspectives rely on file contents + grep-based import tracin
 | 4 | Performance | N+1 queries? Unnecessary computation? Bundle impact? Hot path? |
 | 5 | DX | Readable? Good names? Actionable errors? Types guide usage? |
 
+### Rules (Active When Rules Files Exist)
+
+| # | Perspective | Trigger | Key Questions |
+|---|------------|---------|---------------|
+| 10 | Rules | Any agent config found (AGENTS.md, CLAUDE.md, .cursorrules, codex.md, .opencode/config, etc.) | Violates project conventions? Contradicts user rules? Ignores documented anti-patterns? |
+
+The Rules perspective uses discovered rules as its checklist (not a built-in checklist). Each finding cites the source file and violated rule text.
+
 ### Conditional (Add When Triggered)
 
 | # | Perspective | Trigger | Key Questions |
@@ -176,16 +224,26 @@ For each active perspective:
 
 ```
 1. Read all changed files
-2. Evaluate against perspective checklist (depth matches mode)
-3. Classify findings:
+2. Use the diff ledger to inspect every changed line range owned by that perspective
+3. Evaluate against perspective checklist (depth matches mode)
+4. Classify findings:
    - PASS: Meets criteria (not shown in output)
    - WARN: Concern, not blocking (severity: low/medium/high)
    - FAIL: Must fix before shipping (BLOCKING)
    - BLOCKS_PRODUCTION: Violates production bar (Production mode only)
-4. Output structured findings per review-output.md template
+5. Update coverage ledger for the reviewed line ranges
 ```
 
 Run perspectives in parallel when possible.
+
+After all perspectives complete:
+
+```
+1. Verify every changed line range is covered
+2. Verify every relevant rule has an explicit verdict
+3. Emit FAIL [Process] for each uncovered line range or unchecked rule
+4. Only return CLEAN / WARNINGS_ONLY when both coverage checks are complete and the output includes the rule coverage ledger
+```
 
 ---
 
@@ -194,6 +252,8 @@ Run perspectives in parallel when possible.
 Follow `references/templates/review-output.md`.
 
 Key format: `{file}:{line} — {severity} [{perspective}] {description}` + `Fix: {action}`.
+
+Process coverage gaps use the same format with `[Process]` as the perspective.
 
 Production mode adds: `Standard: {Company} — {rule violated}` line under BLOCKS_PRODUCTION findings.
 

--- a/workflow/references/actions/review.md
+++ b/workflow/references/actions/review.md
@@ -4,6 +4,10 @@
 
 Auto-selecting multi-perspective code review. Runs during ship loop or standalone.
 
+**Portability rule:** this file defines the review contract, not a specific runtime implementation. Use `references/reviews/core-portable-review-spec.md` as the normative portable standard. Runtime-specific orchestration is optional and belongs in executor guidance, not in the core contract.
+
+**Implementation note:** command snippets and tool names in this file are illustrative examples, not mandatory dependencies. Any executor may substitute equivalent mechanisms as long as it preserves the same coverage, rule-checking, and artifact requirements.
+
 ---
 
 ## Step 1: Change Overview (ALWAYS FIRST)
@@ -27,6 +31,12 @@ Before any review, build a change map **and a line-coverage ledger**:
    → Use to refine Risk Classification below (more precise than filename-based heuristics)
    If CI unavailable: use filename-based risk classification only
 ```
+
+### Core Portable Review Contract (MANDATORY)
+
+See `references/reviews/core-portable-review-spec.md` for the normative portable contract and `references/reviews/executor-patterns.md` for optional implementation examples.
+
+This action file describes the workflow-level review policy. It must remain valid whether review is executed by one agent, many agents, a CI system, or a human operator.
 
 ### Coverage Contract (MANDATORY)
 
@@ -137,10 +147,11 @@ No config files found or no relevant rules → skip Rules perspective entirely.
 | Testability | Complex branching (>=3 paths), critical business logic, stateful flows |
 | Accessibility | UI components, forms, navigation, interactive elements |
 
-### Structural Context (TypeScript projects with CI)
+### Structural Context (TypeScript projects with CI or equivalent tooling)
 
-Before dispatching perspective agents in Standard/Deep/Production modes, gather structural data:
+Before dispatching perspectives in Standard/Deep/Production modes, gather structural data when compatible tooling exists.
 
+**Example implementation:**
 ```
 For each changed TS/TSX file:
   npx codebase-intelligence dependents --json <file>
@@ -165,7 +176,7 @@ If CI unavailable: perspectives rely on file contents + grep-based import tracin
 - **Context loaded:** This file + `references/reviews/production-standards.md`
 - **Additional:** Expert personas, company bar evaluation, language-specific overlay
 
-**Production execution:**
+**Production execution (example implementation):**
 
 ```
 1. Load references/reviews/production-standards.md
@@ -236,6 +247,8 @@ For each active perspective:
 
 Run perspectives in parallel when possible.
 
+Parallelism is optional. Executors may review sequentially or in parallel as long as they preserve the same coverage and artifact requirements.
+
 After all perspectives complete:
 
 ```
@@ -249,7 +262,9 @@ After all perspectives complete:
 
 ## Output
 
-Follow `references/templates/review-output.md`.
+Follow `references/templates/review-output.md` for the human-readable summary.
+
+In addition, emit a machine-readable artifact equivalent to the schema in `references/reviews/core-portable-review-spec.md`.
 
 Key format: `{file}:{line} — {severity} [{perspective}] {description}` + `Fix: {action}`.
 

--- a/workflow/references/reviews/core-portable-review-spec.md
+++ b/workflow/references/reviews/core-portable-review-spec.md
@@ -1,0 +1,182 @@
+# Core Portable Review Spec
+
+Tool-agnostic review contract for `workflow`'s `review` action.
+
+Use this file to keep the review standard portable across Hermes, Claude Code, Codex, Cursor, Aider, CI, and human/manual execution.
+
+## Purpose
+
+Separate **review policy** from **review executor**.
+
+- **Core portable review spec** = what must happen
+- **Executor / adapter** = how a specific runtime performs it
+
+The core spec is the OSS asset. Executors are optional implementations.
+
+## Non-Goals
+
+This spec does **not** require:
+- a specific model
+- a specific coding agent
+- Hermes tools
+- Claude Code
+- Codex
+- tmux
+- harness or any local shell wrapper
+
+If a runtime can produce the required evidence, it can implement this spec.
+
+## Required Inputs
+
+Every review must operate on:
+- base ref or previous review point
+- head ref or current working state
+- changed files
+- changed hunks / exact line ranges
+- discovered project rules
+- optionally loaded user rules
+- per-file category and risk classification
+
+## Required Phases
+
+1. Discover the diff
+2. Build a line-range ledger for all changed hunks
+3. Discover and normalize relevant rules
+4. Assign reviewer responsibility by perspective and risk
+5. Review each changed hunk
+6. Review each relevant rule one by one
+7. Merge findings and resolve conflicts per policy
+8. Emit human-readable summary + machine-readable artifacts
+
+## Coverage Contract
+
+A review is only complete when both are true:
+
+1. **Line coverage** — every changed hunk / line range has an explicit verdict
+2. **Rule coverage** — every relevant rule has an explicit verdict
+
+No clean verdict without both.
+
+## Verdict Vocabulary
+
+Use fixed states only:
+- `PASS`
+- `WARN`
+- `FAIL`
+- `NOT_APPLICABLE`
+
+Optional merged state for final arbitration:
+- `REQUIRES_HUMAN_REVIEW`
+
+## Blocking Conditions
+
+The review must block when any of the following is true:
+- a changed hunk has no verdict
+- a relevant rule has no verdict
+- a mandatory project rule source could not be loaded
+- any finding is `FAIL`
+- high-risk conflicts remain unresolved
+- required output artifacts are missing or invalid
+
+## Rule Source Policy
+
+Rule sources are split into:
+- **Project-level** — stable, repo-owned, reproducible; can block
+- **User-level** — environment-specific overlays; must be reported explicitly when loaded
+
+Default OSS-safe posture:
+- CI / shared review mode: project-level rules only
+- local enhanced review mode: project + user rules, with source disclosure
+
+Never claim a user-level rule was checked unless that source was actually loaded.
+
+## Reviewer Assignment Model
+
+The spec requires assignment by hunk, not vague global review.
+
+Minimum contract:
+- every changed hunk has at least one assigned review perspective
+- high-risk hunks may require an additional perspective or second opinion
+- the executor may use one reviewer, many reviewers, humans, or agents
+- the assignment and reviewer identity must be recorded in the artifact
+
+## Executor Contract
+
+An executor is any system that can consume the review inputs and emit the required evidence.
+
+Examples:
+- single-agent local review
+- multiple parallel subagents
+- human reviewer with a checklist
+- CI validator
+- external coding-agent orchestration
+
+Executors may differ, but they must all emit the same review evidence.
+
+## Required Artifacts
+
+At minimum, the review output must contain:
+
+### Human-readable summary
+- change overview
+- coverage summary
+- rule coverage ledger
+- per-file findings
+- final verdict
+
+### Machine-readable artifact
+The executor must emit a structured artifact equivalent to:
+
+```json
+{
+  "review_id": "string",
+  "base_ref": "string",
+  "head_ref": "string",
+  "rule_sources_loaded": {
+    "project": [],
+    "user": [],
+    "unavailable": []
+  },
+  "changed_hunks": [
+    {
+      "file": "string",
+      "range": "string",
+      "category": "string",
+      "risk": "LOW|MEDIUM|HIGH",
+      "assigned_perspectives": [],
+      "reviewed_by": [],
+      "verdict": "PASS|WARN|FAIL|NOT_APPLICABLE"
+    }
+  ],
+  "rule_checks": [
+    {
+      "rule_id": "string",
+      "source": "string",
+      "applies_to": [],
+      "verdict": "PASS|WARN|FAIL|NOT_APPLICABLE"
+    }
+  ],
+  "findings": [],
+  "final_verdict": "CLEAN|WARNINGS_ONLY|HAS_BLOCKERS|REQUIRES_HUMAN_REVIEW"
+}
+```
+
+The exact file name is executor-specific. The schema contract is not.
+
+## Merge / Conflict Policy
+
+If multiple reviewers or systems contribute findings:
+- any `FAIL` blocks
+- conflicting `PASS` / `WARN` results should be surfaced
+- unresolved high-risk conflicts become `REQUIRES_HUMAN_REVIEW`
+- missing assigned reviewer output is a process failure
+
+## Portability Rule
+
+The `workflow` skill must describe the review contract in a way that remains valid even when:
+- no subagents exist
+- no external model CLIs exist
+- no CI exists
+- only a human operator is available
+
+Runtime-specific orchestration belongs in optional executor guidance, not in the core review contract.

--- a/workflow/references/reviews/core-portable-review-spec.md
+++ b/workflow/references/reviews/core-portable-review-spec.md
@@ -2,7 +2,7 @@
 
 Tool-agnostic review contract for `workflow`'s `review` action.
 
-Use this file to keep the review standard portable across Hermes, Claude Code, Codex, Cursor, Aider, CI, and human/manual execution.
+Use this file to keep the review standard portable across agent runtimes, CI systems, and human/manual execution.
 
 ## Purpose
 
@@ -18,11 +18,9 @@ The core spec is the OSS asset. Executors are optional implementations.
 This spec does **not** require:
 - a specific model
 - a specific coding agent
-- Hermes tools
-- Claude Code
-- Codex
-- tmux
-- harness or any local shell wrapper
+- a specific CLI or orchestration tool
+- a specific terminal/session manager
+- a specific local shell wrapper or harness
 
 If a runtime can produce the required evidence, it can implement this spec.
 

--- a/workflow/references/reviews/executor-patterns.md
+++ b/workflow/references/reviews/executor-patterns.md
@@ -1,0 +1,89 @@
+# Review Executor Patterns
+
+Optional implementations of the core portable review spec.
+
+This file is intentionally non-normative. It describes ways to execute the review contract, not the contract itself.
+
+## Rule
+
+Any executor is acceptable if it can:
+- inspect every changed hunk
+- inspect every relevant rule
+- emit explicit verdicts
+- produce the required review evidence
+
+## Executor Types
+
+### 1. Single-agent executor
+One agent performs the full review sequentially.
+
+Use when:
+- diff is small
+- no parallelism is available
+- human/operator cost matters more than redundant review depth
+
+### 2. Multi-reviewer executor
+Multiple specialized reviewers split responsibility by perspective or risk.
+
+Use when:
+- diff is medium/large
+- high-risk hunks exist
+- independent second opinions materially reduce risk
+
+Typical roles:
+- Correctness reviewer
+- Security reviewer
+- Reliability reviewer
+- Rules auditor
+
+### 3. Human/manual executor
+A human follows the review contract using the same ledgers and verdict vocabulary.
+
+Use when:
+- automation is unavailable
+- changes are highly sensitive
+- final arbitration is required
+
+### 4. CI validator / enforcement layer
+A CI validator does not need to perform all reasoning itself. It can validate that required review artifacts exist and are complete, or validate artifacts produced by another executor.
+
+Use when:
+- enforcing minimum review coverage
+- ensuring reproducibility in shared repos
+- blocking merges when required evidence is missing
+
+## Runtime-specific examples
+
+Possible adapters include:
+- Hermes subagents
+- Claude Code specialist sessions
+- Codex review sessions
+- Cursor / Aider / OpenCode workflows
+- bespoke CI or scripting layers
+
+These are examples only. The core workflow skill should never require one of them by name.
+
+## Recommended OSS posture
+
+For open-source repositories:
+- keep the core review contract runtime-neutral
+- document adapters as optional examples
+- avoid making the review standard depend on one vendor, one model, or one local harness
+- treat adapter docs as replaceable implementation details
+
+## Selection Guidance
+
+Choose the smallest executor that still satisfies the contract:
+- low-risk docs change → single-agent executor may be enough
+- high-risk auth/API/infra change → multi-reviewer executor is better
+- shared CI enforcement → validate artifacts even if the reasoning was done elsewhere
+
+## Anti-patterns
+
+Avoid these in the core review contract:
+- “must call tool X”
+- “must use model Y”
+- “must spawn subagents”
+- “must use harness/Hermes/Claude/Codex”
+
+Those statements make the OSS skill less portable and harder to maintain.

--- a/workflow/references/reviews/executor-patterns.md
+++ b/workflow/references/reviews/executor-patterns.md
@@ -55,10 +55,9 @@ Use when:
 ## Runtime-specific examples
 
 Possible adapters include:
-- Hermes subagents
-- Claude Code specialist sessions
-- Codex review sessions
-- Cursor / Aider / OpenCode workflows
+- generic subagent orchestration
+- external specialist review sessions
+- editor-integrated review workflows
 - bespoke CI or scripting layers
 
 These are examples only. The core workflow skill should never require one of them by name.
@@ -67,8 +66,8 @@ These are examples only. The core workflow skill should never require one of the
 
 For open-source repositories:
 - keep the core review contract runtime-neutral
-- document adapters as optional examples
-- avoid making the review standard depend on one vendor, one model, or one local harness
+- document adapters as optional examples only when they add real value
+- avoid making the review standard depend on one vendor, one model, or one local wrapper
 - treat adapter docs as replaceable implementation details
 
 ## Selection Guidance
@@ -84,6 +83,6 @@ Avoid these in the core review contract:
 - “must call tool X”
 - “must use model Y”
 - “must spawn subagents”
-- “must use harness/Hermes/Claude/Codex”
+- “must use runtime Z”
 
 Those statements make the OSS skill less portable and harder to maintain.

--- a/workflow/references/rules-discovery.md
+++ b/workflow/references/rules-discovery.md
@@ -38,7 +38,8 @@ No files found at either level → skip rules enforcement for this action.
 
 Review reproducibility rule:
 - Project-level rule files are the stable, repo-owned baseline.
-- User-level rule files are environment-specific and must be reported explicitly when loaded.
+- User-level rule files are environment-specific overlays and must be reported explicitly when loaded.
+- Shared / CI review should default to project-level rules only.
 - If a user-level rule source is unavailable in the current reviewer environment, do not pretend it was checked. Report it as unavailable and only claim coverage for the rule sources actually loaded.
 
 (Canonical file list shared with `references/memory-update.md` Step 1.)

--- a/workflow/references/rules-discovery.md
+++ b/workflow/references/rules-discovery.md
@@ -1,0 +1,113 @@
+# Rules Discovery Protocol
+
+> **Agent:** Load this file during `review` before dispatching perspectives. Read project/user agent config files, extract rules, and enforce them one by one against the changed scope.
+
+Agent-agnostic. Works with any coding agent ecosystem.
+
+---
+
+## Step 1: Discover Config Files
+
+Read **all** that exist at both levels:
+
+```
+Project-level (check all):
+  {project}/CLAUDE.md                  (Claude Code)
+  {project}/.claude/CLAUDE.md          (Claude Code)
+  {project}/.claude/rules/*            (Claude Code sub-rules)
+  {project}/AGENTS.md                  (universal — any agent)
+  {project}/.cursorrules               (Cursor)
+  {project}/.windsurfrules             (Windsurf)
+  {project}/.aider.conf.yml            (Aider)
+  {project}/.continue/config.json      (Continue)
+  {project}/codex.md                   (Codex)
+  {project}/.opencode/config           (OpenCode)
+
+User-level (check all):
+  ~/.claude/CLAUDE.md                  (Claude Code)
+  ~/.claude/rules/*                    (Claude Code sub-rules)
+  ~/.cursorrules                       (Cursor)
+  ~/.windsurfrules                     (Windsurf)
+  ~/.aider.conf.yml                    (Aider)
+  ~/.continue/config.json              (Continue)
+  ~/.codex/config or ~/codex.md        (Codex)
+  ~/.opencode/config                   (OpenCode)
+```
+
+No files found at either level → skip rules enforcement for this action.
+
+Review reproducibility rule:
+- Project-level rule files are the stable, repo-owned baseline.
+- User-level rule files are environment-specific and must be reported explicitly when loaded.
+- If a user-level rule source is unavailable in the current reviewer environment, do not pretend it was checked. Report it as unavailable and only claim coverage for the rule sources actually loaded.
+
+(Canonical file list shared with `references/memory-update.md` Step 1.)
+
+## Step 2: Extract & Prioritize Rules
+
+1. Extract actionable rules: coding standards, conventions, anti-patterns, quality requirements, forbidden patterns
+2. Normalize them into a numbered checklist with source attribution:
+   - `RULE-1 | source | scope | strength | rule text`
+   - Example: `RULE-3 | ~/.claude/CLAUDE.md | git | MUST | Use worktrees for parallel feature work`
+3. **Precedence: project-level rules override user-level rules.** On conflict, project wins.
+4. Merge non-conflicting rules from both levels into a single rules set
+
+## Step 3: Filter for Relevance
+
+Match rules against the action's scope:
+
+| Signal | Filter |
+|--------|--------|
+| Language | Skip Python rules if only TypeScript files involved |
+| Category | Skip UI rules if no UI files in scope |
+| Path | Skip rules targeting specific paths not in scope |
+| Changed hunk | Skip rules that do not apply to the changed line ranges being reviewed |
+| Always-applicable | Naming, style, security, git rules apply to everything |
+
+For `review`, filtering must stay explicit:
+- Keep a `relevant_rules[]` list
+- For each rule, note which changed files/hunks it applies to
+- If applicability is unclear in Production mode, treat as relevant and fail closed
+
+No relevant rules after filtering → skip rules enforcement.
+
+## Step 4: Classify Severity
+
+| Rule Signal | Severity |
+|-------------|----------|
+| MUST, ALWAYS, NEVER, REQUIRED, BLOCKING | FAIL |
+| SHOULD, PREFER, RECOMMEND, AVOID | WARN (high) |
+| No explicit strength signal | WARN (medium) |
+| Production mode (review/focus only) | Ambiguous rules → FAIL |
+
+For `review`, every relevant rule must end with an explicit verdict for the changed scope:
+- `PASS` — checked and respected
+- `WARN` — checked and partially respected / non-blocking deviation
+- `FAIL` — checked and violated
+- `NOT_APPLICABLE` — rule exists but does not apply to the specific changed files/hunks
+
+Missing verdicts are process failures, not silent skips.
+
+## How Review Uses This
+
+| Phase | How Rules Apply |
+|------|------------------|
+| **Before perspective dispatch** | Discover project-level + user-level config files and extract rules. |
+| **Before Rules perspective runs** | Filter rules to the changed files/hunks and assign explicit applicability. |
+| **During review** | Check each relevant rule one by one against changed files/hunks. Missing rule verdicts are FAIL [Process]. |
+| **In findings** | Rules violations use the `[Rules]` tag plus source-file attribution. |
+
+## Output Format (When Reporting Violations)
+
+```
+{file}:{line} — {FAIL|WARN} [Rules] {violation description}
+  Fix: {concrete action}
+  Rule: {source file} § {section} — "{rule text}"
+```
+
+Example:
+```
+src/api/users.ts:5 — FAIL [Rules] Missing explicit return type on exported function
+  Fix: Add return type annotation to `getUsers()`
+  Rule: AGENTS.md § TypeScript — "Explicit return types on public APIs"
+```

--- a/workflow/references/templates/review-output.md
+++ b/workflow/references/templates/review-output.md
@@ -110,10 +110,13 @@ After all per-file findings:
 1. `{file}:{line}` — [{perspective}] {description} (severity)
 2. `{file}:{line}` — [{perspective}] {description} (severity)
 
-**Verdict:** {CLEAN / HAS_BLOCKERS / WARNINGS_ONLY}
+**Verdict:** {CLEAN / HAS_BLOCKERS / WARNINGS_ONLY / REQUIRES_HUMAN_REVIEW}
 ```
 
 ---
+
+### Machine-readable artifact
+The executor must emit a structured artifact equivalent to the schema in `references/reviews/core-portable-review-spec.md`.
 
 ## Output Rules
 
@@ -127,7 +130,7 @@ After all per-file findings:
 - **Rule ledger required** — include explicit per-rule verdict rows for every relevant loaded rule.
 - **No gap claims without proof** — CLEAN/WARNINGS_ONLY requires full line coverage + rule coverage.
 - **Loaded sources only** — never claim user-level rules were checked unless their source files were loaded.
-- **Verdict at the end** — CLEAN (0 FAIL, 0 WARN), WARNINGS_ONLY (0 FAIL, N WARN), HAS_BLOCKERS (N FAIL).
+- **Verdict at the end** — CLEAN (0 FAIL, 0 WARN), WARNINGS_ONLY (0 FAIL, N WARN), HAS_BLOCKERS (N FAIL), REQUIRES_HUMAN_REVIEW (coverage complete but high-risk conflict unresolved).
 
 ---
 
@@ -149,15 +152,22 @@ The `Standard:` line cites which company bar and specific rule was violated (e.g
 
 ### Production Verdict
 
-Replace standard verdict with production-specific:
+Replace standard verdict with production-specific human-readable wording:
 
 ```markdown
-**Production Verdict:** {PRODUCTION_READY / NOT_PRODUCTION_READY / WARNINGS_ONLY}
+**Production Verdict:** {PRODUCTION_READY / NOT_PRODUCTION_READY / WARNINGS_ONLY / REQUIRES_HUMAN_REVIEW}
 ```
+
+Portable artifact mapping:
+- `PRODUCTION_READY` → `CLEAN`
+- `NOT_PRODUCTION_READY` → `HAS_BLOCKERS`
+- `WARNINGS_ONLY` → `WARNINGS_ONLY`
+- `REQUIRES_HUMAN_REVIEW` → `REQUIRES_HUMAN_REVIEW`
 
 - `PRODUCTION_READY` — 0 BLOCKS_PRODUCTION, 0 FAIL, 0 WARN
 - `NOT_PRODUCTION_READY` — any BLOCKS_PRODUCTION or FAIL exists
 - `WARNINGS_ONLY` — 0 BLOCKS_PRODUCTION, 0 FAIL, N WARN
+- `REQUIRES_HUMAN_REVIEW` — coverage complete but high-risk production conflict remains unresolved
 
 ### Severity Order
 

--- a/workflow/references/templates/review-output.md
+++ b/workflow/references/templates/review-output.md
@@ -11,10 +11,10 @@ Before findings, show the change map from Step 1 of review.md:
 ```markdown
 ## Change Overview
 
-| File | Category | Risk | Language |
-|------|----------|------|----------|
-| src/api/auth.ts | auth/security | HIGH | TypeScript |
-| src/lib/utils.ts | internal logic | LOW | TypeScript |
+| File | Changed lines | Category | Risk | Language |
+|------|---------------|----------|------|----------|
+| src/api/auth.ts | new: 12-31, 40-48 | auth/security | HIGH | TypeScript |
+| src/lib/utils.ts | new: 7-9 | internal logic | LOW | TypeScript |
 
 **Mode:** {MODE} — {reason}
 **Language:** {language} | **Framework:** {framework}
@@ -22,8 +22,57 @@ Before findings, show the change map from Step 1 of review.md:
 
 Rules:
 - Always show the change map table before any findings
+- Include exact changed line coverage per file
 - State selected mode and reason on its own line
 - State detected language and framework
+
+---
+
+## Coverage Summary
+
+After the change overview and before per-file findings:
+
+```markdown
+## Coverage Summary
+
+- Rule sources loaded:
+  - Project: {list | none}
+  - User: {list | none}
+- Changed files: {N}
+- Changed line ranges reviewed: {N}/{N}
+- Relevant rules checked one by one: {N}/{N}
+- Uncovered line ranges: {none | list}
+- Unchecked rules: {none | list}
+- Unavailable rule sources: {none | list}
+```
+
+Rules:
+- Do not claim CLEAN or WARNINGS_ONLY unless both reviewed counts equal total counts
+- If any line ranges are uncovered, emit FAIL [Process] findings for them
+- If any relevant rules are unchecked, emit FAIL [Process] findings for them
+- Never imply user-level rules were checked unless their source files were actually loaded
+
+---
+
+## Rule Coverage Ledger
+
+After the coverage summary and before per-file findings:
+
+```markdown
+## Rule Coverage Ledger
+
+| Rule ID | Source | Applies to | Verdict |
+|---------|--------|------------|---------|
+| RULE-1 | AGENTS.md | src/api/auth.ts new:12-31 | PASS |
+| RULE-2 | ~/.claude/CLAUDE.md | src/api/auth.ts new:12-31,40-48 | FAIL |
+| RULE-3 | ~/.claude/CLAUDE.md | src/lib/utils.ts new:7-9 | NOT_APPLICABLE |
+```
+
+Rules:
+- Include one row per relevant rule
+- Verdict must be one of PASS | WARN | FAIL | NOT_APPLICABLE
+- `Applies to` must point to the changed files/hunks checked for that rule
+- If a rule source was unavailable, list it in Coverage Summary instead of fabricating ledger rows
 
 ---
 
@@ -74,6 +123,10 @@ After all per-file findings:
 - **Flat list** — no nested sections per perspective. One flat list sorted by severity (FAIL first, then WARN).
 - **Concrete fixes** — "Add `await` before `db.save()`" not "Consider handling async properly".
 - **Short** — one line per issue. Description ≤ 80 chars. Fix ≤ 80 chars.
+- **Coverage first** — include coverage summary before findings.
+- **Rule ledger required** — include explicit per-rule verdict rows for every relevant loaded rule.
+- **No gap claims without proof** — CLEAN/WARNINGS_ONLY requires full line coverage + rule coverage.
+- **Loaded sources only** — never claim user-level rules were checked unless their source files were loaded.
 - **Verdict at the end** — CLEAN (0 FAIL, 0 WARN), WARNINGS_ONLY (0 FAIL, N WARN), HAS_BLOCKERS (N FAIL).
 
 ---


### PR DESCRIPTION
## Summary
- require review mode to build a line-coverage ledger for every changed hunk
- add dedicated rules discovery and rule-by-rule coverage requirements
- require review output to include both human-readable summary and machine-readable artifact expectations
- define a runtime-neutral portable review spec plus optional executor patterns so the workflow skill stays OSS-safe and implementation-agnostic

## What changed
- added `workflow/references/reviews/core-portable-review-spec.md` as the normative contract
- added `workflow/references/reviews/executor-patterns.md` for optional implementation patterns
- removed runtime/vendor references from the core portable spec and executor guidance
- updated `review.md`, `review-output.md`, and `rules-discovery.md` to align with the runtime-neutral contract
- updated `workflow/SKILL.md`, `workflow/README.md`, and `CHANGELOG.md` to reflect the new framing

## Verification
- inspected the workflow diff and references end-to-end
- ran independent review passes on the documentation diff and fixed the blocking inconsistencies they found
- verified branch push and PR update via gh

## Notes
- project-level rules remain the reproducible baseline for shared / CI review
- user-level rules are optional overlays when loaded and must be disclosed explicitly
- runtime-specific orchestration is not part of the core review contract
- named config-file conventions remain in rules discovery where they are necessary for interoperability
