### PR TITLE
fix(oss-readiness): make frontmatter valid yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.13.4] - 2026-04-17
+
+- fix(oss-readiness): make SKILL.md frontmatter valid YAML so strict indexers can parse the skill
+
 ## [1.13.3] - 2026-04-17
 
 - feat(github): add release-title prerequisites and preview-aware release strategy guidance

--- a/oss-readiness/SKILL.md
+++ b/oss-readiness/SKILL.md
@@ -6,7 +6,9 @@ description: |
   Triggers: "oss", "/oss", "open source readiness", "release readiness", "public release",
   "go public", "oss audit", "llms.txt", "generate llms", "version bump docs", "scaffold OSS files",
   "release title", "release messaging", "release notes", "announcement quality".
-compatibility: Agent Skills spec (agentskills.io). Works with any agent product that supports SKILL.md frontmatter + Markdown. Optional CLI helpers: git, gh, grep, find, jq, node or python.
+compatibility: |
+  Agent Skills spec (agentskills.io). Works with any agent product that supports SKILL.md frontmatter + Markdown.
+  Optional CLI helpers: git, gh, grep, find, jq, node or python.
 metadata:
   version: "0.2"
 ---


### PR DESCRIPTION
## Summary
- fix the `oss-readiness` skill frontmatter so it parses as valid YAML
- change `compatibility` from a plain scalar containing `:` to a block scalar
- keep the skill content unchanged apart from the frontmatter formatting fix

## Root cause
- the frontmatter parser choked on `Optional CLI helpers:` inside an unquoted scalar
- that made the skill invalid for strict YAML frontmatter consumers, which is why it was missing from skills.sh indexing

## Verification
- parsed the frontmatter with Python `yaml.safe_load`
