### PR TITLE
feat(convex): add FilterApi TS2589 guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.13.5] - 2026-04-17
+
+- feat(convex): add FilterApi TS2589 guardrails, recovery guidance, and module-count checks
+
 ## [1.13.4] - 2026-04-17
 
 - fix(oss-readiness): make SKILL.md frontmatter valid YAML so strict indexers can parse the skill

--- a/convex/README.md
+++ b/convex/README.md
@@ -10,6 +10,7 @@ Convex skill for building and operating Convex backends: functions, schemas, aut
 - Components: `convex/references/components.md`
 - Migrations: `convex/references/migrations.md`
 - Performance: `convex/references/performance.md`
+- Troubleshooting / TS2589: `convex/references/troubleshooting.md`
 - MCP usage (recommended): `convex/references/mcp.md`
 - CLI usage/help: `convex/references/cli-help.md`
 - Validation checklist: `convex/checklists/validation.md`

--- a/convex/SKILL.md
+++ b/convex/SKILL.md
@@ -8,7 +8,7 @@ description: |
   "cron", "schedule", "workflow", "workpool", "ctx.db", "ctx.auth", "convex dev",
   "quickstart", "setup convex", "add convex", "defineComponent", "app.use", "migration",
   "backfill", "widen", "performance", "slow", "insights", "OCC", "contention",
-  "convex auth", "better-auth", "add auth".
+  "convex auth", "better-auth", "add auth", "TS2589", "FilterApi", "fullApi".
 license: MIT
 compatibility: Works best with Convex MCP (recommended) or Convex CLI (npx convex). Targets repos with a `convex/` directory.
 metadata:
@@ -88,6 +88,30 @@ Docs: https://github.com/vllnt/eslint-config
 
 See `references/style.md` and `references/testing.md`.
 
+## FilterApi / TS2589 Guardrail (Blocking)
+
+Convex codegen adds every `.ts` and `.js` file under `convex/` to `fullApi`, including utility-only files that export zero Convex functions. TypeScript then applies `FilterApi<fullApi, "public">` and `FilterApi<fullApi, "internal">` recursively. At roughly 350+ modules, that recursion can trip TS2589 (`Type instantiation is excessively deep and possibly infinite`).
+
+Treat this as a structural scaling limit, not a random TypeScript glitch.
+
+Rules:
+
+- Do not create utility-only files in `convex/` for helpers, validators, schemas, types, or constants if they can live in `src/`.
+- Do not split one logical Convex scope into many tiny files just for organization; each extra file adds `fullApi` depth.
+- When TS2589 appears, check generated module count before doing anything else.
+- Prefer `actionGeneric`, `queryGeneric`, `mutationGeneric`, `internalActionGeneric`, `internalQueryGeneric`, and `internalMutationGeneric` from `convex/server` when deep generated types are part of the problem.
+- Config-only or bridge files that do not need TypeScript checking can be `.js` only when that is an intentional escape hatch and the repo accepts it.
+- Thin bridge layers that proxy `internal.*` calls may need explicit type cut points (`any`/lint disable with comment) to break recursive type chains.
+
+Module-count guardrail:
+
+```bash
+grep -c '  "' convex/_generated/api.d.ts
+```
+
+- `> 330`: warn that the repo is approaching the FilterApi TS2589 limit
+- `> 350`: treat as likely to fail and block further file-splitting inside `convex/`
+
 ## Router
 
 | User says | Load reference | Do |
@@ -104,7 +128,7 @@ See `references/style.md` and `references/testing.md`.
 | http / webhook | `references/patterns/http.md` | httpRouter/httpAction patterns |
 | testing | `references/testing.md` | testing patterns |
 | ecosystem / components | `references/ecosystem.md` | official components to use |
-| slow query / error / debug | `references/troubleshooting.md` | troubleshooting + anti-patterns |
+| slow query / error / debug / TS2589 / FilterApi | `references/troubleshooting.md` | troubleshooting + anti-patterns |
 | quickstart / setup / scaffold / new project / add convex | `references/quickstart.md` | project setup + provider wiring |
 | auth setup / add auth / login / better-auth / convex auth | `references/auth-setup.md` | auth provider selection + setup |
 | component / defineComponent / app.use / extract module | `references/components.md` | component design + boundary rules |
@@ -131,7 +155,7 @@ If Convex MCP is not available, this skill still works:
 
 Full workflow: `references/mcp.md`.
 
-## Critical Rules (14)
+## Critical Rules (16)
 
 1) Always use validators (`args` + `returns`) for functions. [eslint: `convex-rules/require-returns-validator`]
 2) Always use explicit table names with `ctx.db.get/patch/replace`. [eslint: `@convex-dev/explicit-table-ids`]
@@ -147,6 +171,8 @@ Full workflow: `references/mcp.md`.
 12) Never use `ctx.db.get/query` inside loop bodies -- use `Promise.all()` with `.map()`. [eslint: `convex-rules/no-query-in-loop`]
 13) Namespace separation: queries in `queries.ts`, mutations in `mutations.ts`, actions in `actions.ts`. [eslint: `convex-rules/namespace-separation`]
 14) No bare `v.any()` outside `validators.ts` -- define named aliases. [eslint: `convex-rules/no-bare-v-any`]
+15) Watch `convex/_generated/api.d.ts` module count; warn above ~330 and treat ~350+ as a FilterApi TS2589 risk threshold.
+16) Keep utility-only files out of `convex/`; move helpers/types/schemas/constants to `src/` unless they must define Convex functions.
 
 ## References
 

--- a/convex/checklists/validation.md
+++ b/convex/checklists/validation.md
@@ -23,6 +23,7 @@
 - [ ] Namespace separation: queries in `queries.ts`, mutations in `mutations.ts`, actions in `actions.ts` [blocking]
 - [ ] No bare `v.any()` outside `validators.ts` [blocking]
 - [ ] snake_case filenames in `convex/` (except config files) [blocking]
+- [ ] No utility-only `helpers.ts` / `validators.ts` / `types.ts` / `schemas.ts` / `constants.ts` added under `convex/` when they could live in `src/` [blocking]
 
 **[advisory]** - Should pass, warn if not:
 
@@ -33,3 +34,4 @@
 - [ ] Components: parent IDs cross boundary as `v.string()` [advisory]
 - [ ] Migrations: dual-write during migration window [advisory]
 - [ ] Performance: `npx convex insights --details` checked for signal [advisory]
+- [ ] Module count from `convex/_generated/api.d.ts` checked when adding files/components; warn above ~330, block above ~350 [advisory]

--- a/convex/references/troubleshooting.md
+++ b/convex/references/troubleshooting.md
@@ -28,6 +28,49 @@ For deep performance diagnosis, see `references/performance.md`.
 1. Check: missing runtime directive?
 2. Fix: follow the official "runtimes" doc and ensure your action is in the correct runtime.
 
+## If TypeScript fails with TS2589 / FilterApi depth errors
+
+Symptom:
+
+- `TS2589: Type instantiation is excessively deep and possibly infinite`
+- usually triggered from `api`, `internal`, `_generated/api`, or `_generated/server`
+
+Root cause chain:
+
+```text
+convex/ has N .ts/.js files
+  -> codegen includes all N in fullApi
+  -> FilterApi<fullApi, "public" | "internal"> recurses across every module
+  -> importing api/internal forces deep type resolution
+  -> around 350+ modules, TypeScript can exceed its recursion budget
+```
+
+Check first:
+
+```bash
+grep -c '  "' convex/_generated/api.d.ts
+```
+
+Interpretation:
+
+- `> 330`: approaching the danger zone
+- `> 350`: likely FilterApi depth failure territory
+
+Preferred fixes, in order:
+
+1. Reduce `convex/` module count. Move utility-only `helpers.ts`, `validators.ts`, `types.ts`, `schemas.ts`, and `constants.ts` into `src/` or merge them into real function files.
+2. Stop splitting one logical scope into many tiny files inside `convex/`.
+3. Replace deep generated builders with `queryGeneric`, `mutationGeneric`, `actionGeneric`, `internalQueryGeneric`, `internalMutationGeneric`, or `internalActionGeneric` from `convex/server` when the generated `DataModel` chain is the problem.
+4. For config-only or bridge files that do not need TypeScript checking, consider `.js` as an intentional escape hatch if the repo accepts it.
+5. For thin bridge layers that only proxy `internal.*` calls, use a clearly documented type cut point (`any` / targeted lint disable) if needed to break the recursive chain.
+
+Anti-patterns to flag immediately:
+
+- utility-only files living inside `convex/`
+- adding new files under `convex/` that export zero Convex functions
+- large `v.union()` literals or deeply nested validators in files that also import `internal` or `api`
+- registering another component with `app.use(...)` when the module count is already near the threshold
+
 Docs:
 
 - Functions: https://docs.convex.dev/functions


### PR DESCRIPTION
## Summary
- document the Convex `FilterApi` / `TS2589` failure mode in the convex skill
- add guidance to keep utility-only files out of `convex/` and prefer `*Generic` builders when type depth is the problem
- add module-count guardrails and validation checks for repos approaching the `fullApi` recursion limit

## What changed
- `convex/SKILL.md`: added a blocking FilterApi/TS2589 guardrail section, new triggers, router entry, and two new critical rules
- `convex/references/troubleshooting.md`: added root-cause chain, thresholds, recovery options, and anti-patterns
- `convex/checklists/validation.md`: added checks for utility-only files in `convex/` and module-count verification
- `convex/README.md`: surfaced troubleshooting/TS2589 entry point
- `CHANGELOG.md`: added release note entry

## Verification
- `git diff --check`
- parsed `convex/SKILL.md` frontmatter with `yaml.safe_load`

Closes #14
