### PR TITLE
docs(skill-builder): make authoring guidance more portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.13.5] - 2026-04-18
+
+- docs(skill-builder): make authoring guidance more portable across agent products with spec-aligned description, validation, and confirmation rules
+
 ## [1.13.4] - 2026-04-17
 
 - fix(oss-readiness): make SKILL.md frontmatter valid YAML so strict indexers can parse the skill

--- a/skill-builder/SKILL.md
+++ b/skill-builder/SKILL.md
@@ -1,15 +1,13 @@
 ---
 name: skill-builder
 description: |
-  Build correct, consistent Agent Skills (create/update/delete/add content) using validated templates,
-  safe defaults, and cross-skill consistency checks.
-  Works across common agent CLIs that load skills from Markdown folders.
-  Triggers: "new skill", "create skill", "build skill", "update skill", "delete skill",
-  "add to skill", "skill template", "skill validation", "skill builder".
+  Build correct, consistent Agent Skills for any compatible agent product. Use when creating,
+  updating, renaming, deleting, or validating a skill, or when improving skill descriptions,
+  structure, safety rules, progressive disclosure, or trigger reliability.
 license: MIT
-compatibility: Agent Skills spec (agentskills.io). Works with any agent product that supports SKILL.md frontmatter + Markdown.
+compatibility: "Agent Skills spec (agentskills.io). Works with any agent product that supports SKILL.md frontmatter + Markdown."
 metadata:
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Skill Builder
@@ -17,71 +15,109 @@ metadata:
 Unified, security-first skill builder.
 
 This skill is intentionally opinionated:
-- Prefer no new skill if a simpler change works (project docs, a script, or a small snippet).
+- Prefer no new skill if a simpler change works.
 - When you do create a skill, make it boring, testable, and hard to misuse.
-- Keep one clear router and avoid overlapping triggers across skills.
+- Keep one clear router and avoid overlapping descriptions across skills.
+- Stay model-agnostic and harness-agnostic unless the target environment explicitly requires otherwise.
 
 ## Operation Router
 
 | User intent | Operation | Output |
 |---|---|---|
-| create/build/make/new skill | CREATE | new skill folder + `SKILL.md` + `README.md` |
-| update/modify/improve skill | UPDATE | minimal diff, keep triggers stable |
-| delete/remove skill | DELETE | remove skill + update repo index |
-| add content/route/workflow to skill | ADD | new router row + new section file (when needed) |
-| validate skill | VALIDATE | checklist results + fixes |
+| create/build/make/new skill | CREATE | new skill folder + `SKILL.md` + only the companion files actually needed |
+| update/modify/improve skill | UPDATE | minimal diff, keep scope stable |
+| delete/remove skill | DELETE | remove skill + update any dependent references |
+| add content/route/workflow to skill | ADD | new router row + minimal supporting procedure |
+| validate skill | VALIDATE | evidence-backed validation report + fixes |
 | rename skill | RENAME | safe rename + reference updates |
+
+## Operation Selection Rules
+
+Use the smallest operation that solves the request:
+
+- **CREATE** — new user-facing capability or clearly distinct intent/description domain.
+- **UPDATE** — improve an existing skill without changing its core scope.
+- **ADD** — add one new route, example, or sub-workflow inside the current scope.
+- **RENAME** — change identity/path/name while preserving mostly the same behavior.
+- **DELETE** — remove obsolete capability because it is superseded, merged, or no longer useful.
+- **VALIDATE** — inspect correctness without broadening scope.
+
+If uncertain, default to **UPDATE** rather than CREATE.
 
 ## What "Correct" Means
 
 This skill treats "correct" as:
 
-- Conforms to the Agent Skills spec (directory + `SKILL.md` frontmatter constraints).
-- Uses progressive disclosure: small `SKILL.md`, deeper docs in `references/`.
-- Has unambiguous activation: specific description + non-overlapping triggers.
-- Is safe: no secrets, no default-destructive commands, tool usage is scoped.
+- Conforms to the Agent Skills spec where the spec is explicit.
+- Uses progressive disclosure: concise `SKILL.md`, deeper docs only when needed.
+- Has unambiguous activation: specific description + non-overlapping neighboring skills.
+- Is safe: no secrets, no default-destructive commands, explicit confirmation boundaries.
+- Produces validation evidence instead of relying on vibes.
 
 ## Phase 0: First-Principles Check (Mandatory)
 
-Run this before ANY CREATE/UPDATE:
+Run this before any CREATE or UPDATE:
 
 1. QUESTION: what problem, for who, measured how?
-2. DELETE: can an existing component/skill/command solve it?
-3. SIMPLIFY: smallest change that works (often a project instruction file)
+2. DELETE: can an existing skill, README section, script, or template solve it?
+3. SIMPLIFY: what is the smallest change that works?
 4. ACCELERATE: only after (2) and (3)
-5. AUTOMATE: create a component only if it will be reused
+5. AUTOMATE: create a new skill only if it will be reused
 
 If the answer is "no skill", propose:
 - a README section
 - a small script
 - a usage snippet users can copy
+- a targeted update to an existing skill
 
 ## Phase 1: Detect Target + Name
 
-### Target repository layout
+### Required by the Agent Skills spec
 
-This repo layout:
+- Skill directory contains `SKILL.md`.
+- `SKILL.md` starts with valid YAML frontmatter.
+- `name` matches the parent directory name.
+- `description` explains what the skill does and when to use it.
 
-- `/<skill-name>/SKILL.md` (home/router)
-- `/<skill-name>/README.md` (short overview)
-- optional: `/<skill-name>/references/*.md` (split workflows)
+### Recommended by this skill
 
-## Spec Rules (Agent Skills)
-
-From the Agent Skills specification:
-
-- Skill folder name must match `name`.
-- `name` constraints: 1-64 chars; lowercase letters/numbers/hyphens; no leading/trailing `-`; no `--`.
-- `description` should say what + when; max 1024 chars.
-- Optional frontmatter fields you may include: `license`, `compatibility`, `metadata`, `allowed-tools`.
-
-Reference: https://agentskills.io/specification
+- Keep `SKILL.md` focused on router + core rules.
+- Add `references/`, `scripts/`, `assets/`, or `README.md` only when they add real value.
+- Keep references one level deep from `SKILL.md`.
+- Put nonstandard metadata under `metadata` instead of inventing new top-level fields.
 
 ### Naming
 
 - Use kebab-case (`my-skill-name`).
 - Avoid generic names (`tools`, `helper`).
-- Prefer verbs for commands (`review-pr`, `sync-main`).
+- Prefer names that describe a distinct job to be done.
+
+### Description design
+
+The `description` field is the primary discovery surface.
+
+Write it to cover:
+- **what** the skill does
+- **when** to use it
+- likely user wording, domain terms, and near-synonyms
+
+Do not depend on a custom top-level `triggers` field for portability. If you want trigger examples, keep them in the body, `metadata`, or eval fixtures.
+
+## Confirmation Boundary
+
+Safe without confirmation:
+- read-only inspection
+- drafting content
+- local validation
+- proposing diffs
+
+Require confirmation before:
+- deleting files or folders
+- renaming skill folders
+- overwriting user-authored content
+- changing trigger semantics in ways that may alter discovery behavior
+- editing repo indexes or catalogs
+- installing dependencies or using networked side effects
 
 ## Phase 2: CREATE Flow
 
@@ -89,121 +125,171 @@ Reference: https://agentskills.io/specification
 
 - Name
 - Goal + non-goals
-- Triggers (what user says)
-- Allowed tools (tightest possible)
+- Description draft that covers what + when
+- Optional capability constraints if the target client supports them
 
 ### CREATE Steps
 
-1. Discover existing conventions (look at other skills in the repo).
-2. Draft a micro-spec (goal/non-goals, routing, tool boundaries).
+1. Discover existing conventions in the target repo.
+2. Draft a micro-spec: goal, non-goals, router, safety boundary.
 3. Create `/<skill-name>/SKILL.md` with:
-   - front matter (name/description + triggers)
+   - frontmatter (`name`, `description`, optional spec-supported fields)
    - router table
-   - safety rules
-   - minimal workflows (or links to `references/`)
-4. Create `/<skill-name>/README.md` with install + entry points.
-5. Validate (see Validation).
-6. If the repo has an index of skills (commonly a `README.md`), add/update the entry.
+   - safety and confirmation rules
+   - short workflows or links to `references/`
+4. Add companion files only if justified:
+   - `README.md` for human-facing install/overview
+   - `references/` for deep workflows
+   - `scripts/` for executable helpers
+   - `assets/` for templates/resources
+5. Validate using the evidence rules below.
+6. If the repo maintains an index, update it.
 
 ### Output Contract (CREATE)
 
-When creating a skill, always return:
-
-- Files created/edited (paths only)
-- Trigger phrases added
-- One minimal "smoke test" prompt (how to activate it)
-- Validation result (pass/fail + what to fix)
+Always return:
+- files created/edited
+- description added or changed
+- whether optional fields like `compatibility`, `metadata`, or `allowed-tools` were used
+- one minimal smoke-test prompt
+- validation report: pass/fail + evidence + remaining risks
 
 ## Phase 3: UPDATE Flow
 
-1. Read current skill.
-2. Identify actual user goal (avoid refactors).
-3. Apply minimal diff.
-4. Re-run validation checklist.
-5. Keep triggers stable unless explicitly requested.
+1. Read the current skill.
+2. Identify the actual user goal.
+3. Apply the smallest diff that solves it.
+4. Re-run validation.
+5. Keep scope and description stable unless a broader change is explicitly requested.
+
+### Output Contract (UPDATE)
+
+Return:
+- files changed
+- behavior changed
+- description change: yes/no
+- validation report
+- risks or follow-ups
 
 ## Phase 4: DELETE Flow
 
-1. Confirm skill folder.
-2. Identify dependents (root `README.md`, other skill references).
-3. Remove skill and update references.
-4. Provide rollback note (restore from git).
+1. Confirm the target skill folder.
+2. Identify dependents: indexes, references, sibling skills.
+3. Remove the skill and update references.
+4. Provide rollback instructions.
+
+### Output Contract (DELETE)
+
+Return:
+- removed paths
+- references updated
+- rollback note
+- validation/report of any remaining broken links
 
 ## Phase 5: ADD Content to a Skill
 
 Rules for skill growth:
-- Never duplicate trigger phrases across multiple skills in the same install.
+- Never duplicate description intent across multiple skills in the same install.
 - Route by intent first, then load deeper sections.
-- Keep SKILL.md readable: prefer short tables + stable templates.
+- Keep `SKILL.md` readable: short tables, stable templates, deep detail in `references/`.
 
 Add steps:
-1. Add one new router row.
+1. Add one new router row or one tightly scoped section.
 2. Add the minimal new procedure.
-3. If it grows: split into `references/<topic>.md`.
-4. Add/adjust examples.
-5. Re-check cross-skill consistency.
+3. If it grows, split into `references/<topic>.md`.
+4. Add or update examples.
+5. Re-check neighboring skills for overlap.
+
+## Phase 6: RENAME Flow
+
+1. Confirm old and new names.
+2. Rename the folder and update frontmatter `name`.
+3. Update internal and repo-level references.
+4. Validate links, name/path parity, and discovery wording.
+
+### Output Contract (RENAME)
+
+Return:
+- old name → new name
+- moved paths
+- references updated
+- validation report
 
 ## Validation
 
+### Validation Requirements
+
+A skill is not validated until you produce evidence for all three layers:
+
+1. **Spec validation** — structure and YAML correctness
+2. **Trigger validation** — the description should trigger when it should, and not trigger on near-misses
+3. **Output validation** — the skill improves or constrains the resulting work on realistic tasks
+
 ### Skill Validation Checklist
 
-- Front matter includes `name` and `description`.
-- Has a router (how to decide what to do).
-- Defines what is safe to run without confirmation vs requires confirmation.
-- No secrets; no links to private paths.
+- Frontmatter includes valid `name` and `description`.
+- Frontmatter is valid YAML, not just visually plausible Markdown metadata.
+- `name` matches the parent directory.
+- Description clearly states what + when.
+- Any extra frontmatter stays within spec-supported fields unless the target environment explicitly supports more.
+- Router is present.
+- Confirmation boundary is explicit.
+- No secrets; no private paths unless the target repo is intentionally private.
 - No unscoped destructive instructions.
-- Trigger hygiene: no overlapping triggers with existing skills in the repo.
-- Docs split: if SKILL.md becomes long, move workflows into `references/`.
+- Progressive disclosure is respected.
+- Trigger hygiene has been checked against neighboring skills.
 
 ### Spec Validation (Recommended)
 
-If you have the reference validator available (optional), run:
+If available:
 
 ```bash
 skills-ref validate ./<skill-name>
 ```
 
-If not available, validate manually using the rules in "Spec Rules" above.
+If not available, validate manually using the rules in `references/validation.md`.
 
-### Tool Safety
+### Capability Safety
 
-- Prefer Read/Glob/Grep before Bash.
-- If Bash is needed, scope it (git-only, or specific commands).
-- Never recommend `rm -rf`, `git reset --hard`, `push --force` as defaults.
+- Prefer the least-privileged capability that can complete the task.
+- Inspect/search before executing commands.
+- If command execution is needed, scope it tightly.
+- Never recommend `rm -rf`, `git reset --hard`, or `push --force` as defaults.
 
 ## Templates
 
-### Skill Front Matter
+### Skill Frontmatter
 
 ```yaml
 ---
 name: my-skill
-description: Describe what the skill does and when to use it. Include trigger phrases.
-compatibility: Optional. Mention required system tools, network needs, or target environments.
+description: Use this skill when you need to do X, Y, or Z. It handles A and B and is relevant when the user asks for C.
+compatibility: Optional. Mention required runtimes, system tools, or environment assumptions.
 metadata:
   version: "0.1"
-allowed-tools: Optional. Space-delimited list. Prefer the narrowest set possible.
+allowed-tools: Optional experimental field. Only include it when the target client supports it and the skill benefits from a constrained tool list.
 ---
 ```
 
-### Progressive Disclosure Pattern
-
-Keep `SKILL.md` as:
+### Minimum Viable Portable Skill
 
 1. Frontmatter
-2. Router table
-3. Safety rules
-4. Short workflows
-5. Links to `references/*.md` for deep details
+2. One-paragraph purpose/activation guidance
+3. Router table
+4. Safety + confirmation rules
+5. Short workflows
+6. Optional `references/` only when needed
 
 ## References
 
 - `references/checklist.md` (authoring checklist)
 - `references/templates.md` (copy/paste templates)
-- `references/validation.md` (validation flow + trigger hygiene)
+- `references/validation.md` (spec, trigger, and output validation)
 
 ## What This Skill Is For (Practical Examples)
 
-- "Create a skill that scaffolds new skills" → create a skill + templates + validation.
-- "Update my git workflow" → improve the router + split workflows into `references/`.
-- "Make skills consistent across repos" → enforce naming/triggers/tool boundaries.
+- "Create a skill that scaffolds new skills" → CREATE.
+- "Make this skill more portable across agent products" → UPDATE.
+- "Rename this skill without breaking references" → RENAME.
+- "Check whether this skill will trigger reliably" → VALIDATE.
+- "Make skills consistent across repos" → UPDATE or ADD, depending on scope.

--- a/skill-builder/references/validation.md
+++ b/skill-builder/references/validation.md
@@ -1,5 +1,7 @@
 # Validation Flow
 
+Use this flow to produce evidence, not just a checklist.
+
 ## 1) Spec Validation
 
 Preferred (if available):
@@ -8,27 +10,69 @@ Preferred (if available):
 skills-ref validate ./<skill-name>
 ```
 
-If `skills-ref` is not available, this skill still works. Do the manual checks in the next section.
-
-If not available, validate manually against:
+If `skills-ref` is not available, validate manually against:
 - https://agentskills.io/specification
+- valid YAML frontmatter parsed by a real parser
+- `name` matches the parent directory
+- `description` covers what the skill does and when to use it
+- only spec-supported top-level fields are used unless the target environment explicitly supports more
 
-## 2) Trigger Hygiene
+YAML pitfalls to check explicitly:
+- Quote values containing `:` followed by text.
+- Do not rely on permissive parsers.
+- Keep extra metadata under `metadata`.
 
-Avoid overlap across skills installed together.
+## 2) Trigger Validation
+
+The description is the primary discovery mechanism.
+
+Build a realistic eval set:
+- ~8-10 prompts that should trigger
+- ~8-10 prompts that should not trigger
+- prioritize near-misses over obviously irrelevant prompts
+- vary tone, detail level, wording, typos, and indirect phrasing
 
 Practical checks:
-
-- Search the repo for the new trigger phrases.
+- Search neighboring skills for overlapping description language.
 - If overlap is unavoidable, rewrite descriptions so each skill has distinct intent keywords.
+- Prefer intent phrases over broad single-word cues.
 
-## 3) Structure + Progressive Disclosure
+Output evidence:
+- which prompts should trigger
+- which prompts should not trigger
+- any ambiguous cases and how the description was tightened
+
+## 3) Output Validation
+
+Run at least 2-3 realistic tasks.
+
+For each task, record:
+- prompt
+- expected behavior
+- whether the skill improved structure, safety, or consistency
+- remaining gaps
+
+If possible, compare:
+- without the skill
+- with the skill
+
+## 4) Structure + Progressive Disclosure
 
 - Keep `SKILL.md` as router + core rules.
 - Split deep workflows into `references/*.md`.
+- Keep references one level deep from `SKILL.md`.
+- Avoid turning `SKILL.md` into a giant playbook.
 
-## 4) Safety
+## 5) Safety
 
 - No secrets.
 - No default destructive commands.
 - Make confirmation boundaries explicit.
+- Prefer the least-privileged capability that can complete the task.
+
+## Validation Report Template
+
+- Spec validation: pass/fail + evidence
+- Trigger validation: pass/fail + prompt set summary
+- Output validation: pass/fail + scenario summary
+- Risks / follow-ups


### PR DESCRIPTION
## Summary
- make `skill-builder` more portable across agent products and harnesses
- align the guidance more tightly with the Agent Skills spec and description-driven discovery
- upgrade validation from checklist-only guidance to evidence-backed spec, trigger, and output validation

## What changed
- add explicit operation selection rules for CREATE, UPDATE, ADD, RENAME, DELETE, and VALIDATE
- make `description` the primary discovery surface instead of implying a custom top-level `triggers` field
- make `README.md`, `references/`, `scripts/`, `assets/`, and `allowed-tools` optional rather than default-required
- replace tool-name guidance with capability-based least-privilege guidance
- add a reusable confirmation boundary and explicit output contracts for the documented mutate/rename/delete flows
- expand `references/validation.md` to cover spec validation, trigger evals, output evals, and validation report structure

## Validation
- parsed `skill-builder/SKILL.md` frontmatter with `yaml.safe_load`
- ran `git diff --check`
- manually checked the updated guidance against the Agent Skills spec and description optimization docs
