### PR TITLE
docs(git): clarify env carry-over for new worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.13.6] - 2026-04-25
+
+- docs(git): clarify env file carry-over for new worktrees so local runtime config is copied intentionally
+
 ## [1.13.5] - 2026-04-18
 
 - docs(skill-builder): make authoring guidance more portable across agent products with spec-aligned description, validation, and confirmation rules

--- a/git/references/worktree-workflow.md
+++ b/git/references/worktree-workflow.md
@@ -41,6 +41,34 @@ If the branch already exists:
 git worktree add <worktrees-dir>/<topic> <type>/<topic>
 ```
 
+## Env file carry-over
+
+When creating a new worktree for active development, copy the repo's existing local env files from the source checkout into the new worktree before starting app work.
+
+Default rule:
+- source checkout = the main repo working directory you launched the worktree from
+- copy project-local `.env*` files that represent active local runtime config
+- preserve relative paths inside the repo
+- do not invent new env values in the worktree
+
+Typical monorepo examples:
+- `apps/mobile/.env.local`
+- `apps/web/.env.local`
+- `packages/backend/.env.local`
+
+Recommended flow after `git worktree add`:
+
+```bash
+# example pattern — copy existing local env files into the new worktree
+rsync -a --relative \
+  apps/mobile/.env.local \
+  apps/web/.env.local \
+  packages/backend/.env.local \
+  <worktree-path>/
+```
+
+If a repo has many env files, discover them first from the source checkout and copy the relevant local env files into the worktree before running app commands.
+
 ## List worktrees
 
 ```bash


### PR DESCRIPTION
## Summary
- document env file carry-over when creating a new worktree for active development
- explain the default expectations for copying existing local `.env*` files
- add a concrete `rsync --relative` example for monorepos

## Testing
- not applicable (docs only)
