### PR TITLE
feat(first-principles): add first-principles thinking skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # 🎯 Agent Skills
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-8-blue.svg)](./#available-skills)
+[![Skills](https://img.shields.io/badge/skills-9-blue.svg)](./#available-skills)
 [![Release](https://img.shields.io/github/v/release/bntvllnt/agent-skills?display_name=tag&sort=semver)](https://github.com/bntvllnt/agent-skills/releases/latest)
 
 **Compatible with:** Claude Code • OpenCode • Windsurf • Cursor • More via [skills.sh](https://skills.sh)
@@ -88,6 +88,14 @@ Complete tmux management: sessions, windows, panes, layouts, and scripting/autom
 
 ---
 
+### [First Principles](./first-principles/) - Decompose & Rebuild
+
+First-principles thinking + 5-step engineering algorithm (popularized by Elon Musk): decompose to physical/economic atoms, then *requirements → delete → simplify → accelerate → automate* in order.
+
+[View skill documentation →](./first-principles/SKILL.md)
+
+---
+
 ## Installation Options
 
 Install specific skill:
@@ -108,6 +116,8 @@ npx skills add bntvllnt/agent-skills --skill convex
 npx skills add bntvllnt/agent-skills --skill workflow
 
 npx skills add bntvllnt/agent-skills --skill tmux
+
+npx skills add bntvllnt/agent-skills --skill first-principles
 ```
 
 Global install:
@@ -127,6 +137,8 @@ npx skills add bntvllnt/agent-skills --skill convex -g
 npx skills add bntvllnt/agent-skills --skill workflow -g
 
 npx skills add bntvllnt/agent-skills --skill tmux -g
+
+npx skills add bntvllnt/agent-skills --skill first-principles -g
 ```
 
 Specific agent:
@@ -146,6 +158,8 @@ npx skills add bntvllnt/agent-skills --skill convex --agent claude-code
 npx skills add bntvllnt/agent-skills --skill workflow --agent claude-code
 
 npx skills add bntvllnt/agent-skills --skill tmux --agent claude-code
+
+npx skills add bntvllnt/agent-skills --skill first-principles --agent claude-code
 ```
 
 ---

--- a/analyze/SKILL.md
+++ b/analyze/SKILL.md
@@ -14,7 +14,7 @@ Use when:
 - Want quick summary OR deep analysis mode
 - Need first-principles brief that challenges assumptions
 
-Triggers: "analyze", "key points", "what's important", "improve this", "review", "examine", "assess", "analysis", "deep analysis", "run deep analysis", "brief", "challenge assumptions", "first principles"
+Triggers: "analyze", "key points", "what's important", "improve this", "review", "examine", "assess", "analysis", "deep analysis", "run deep analysis", "brief", "challenge assumptions"
 
 ## Agent Capabilities
 

--- a/docs/skills-overview.md
+++ b/docs/skills-overview.md
@@ -14,6 +14,7 @@ Agent Skills is a collection of reusable AI agent capabilities, distributed via 
 | [convex](../convex/SKILL.md) | Convex backend: functions, schemas, auth, scheduling |
 | [workflow](../workflow/SKILL.md) | High-velocity solo development: plan, ship, fix, review, done |
 | [tmux](../tmux/SKILL.md) | Terminal multiplexer: sessions, windows, panes, layouts |
+| [first-principles](../first-principles/SKILL.md) | First-principles thinking + 5-step engineering algorithm |
 
 ## How Skills Work
 

--- a/first-principles/README.md
+++ b/first-principles/README.md
@@ -1,0 +1,44 @@
+# First Principles
+
+First-principles thinking and 5-step engineering algorithm (popularized by Elon Musk). Break problems down to fundamentals and rebuild solutions from scratch.
+
+## What This Does
+
+Two composable frameworks:
+
+- **First-Principles Thinking** — decompose a stated cost / constraint / belief into its physical or economic atoms, compute the irreducible floor, and reconstruct from there. Counters reasoning-by-analogy.
+- **5-Step Algorithm** — *make requirements less dumb → delete the part → simplify → accelerate → automate*, run in order. Counters premature optimization and automating broken processes.
+
+## When To Use
+
+| Situation | Framework |
+|-----------|-----------|
+| "Industry says X costs Y" | First Principles |
+| "Everyone does it like this" | First Principles |
+| Designing or fixing a process / system | 5-Step Algorithm |
+| Hard problem with both: cost belief + process | 1, then 2 |
+
+## Entry Points
+
+| Say | Action |
+|-----|--------|
+| "first principles on [X]" | Run 4-step decomposition on X |
+| "what does the physics say about [X]" | Compute physical-cost floor for X |
+| "5-step algorithm on [process]" | Run musk algorithm in order |
+| "delete the part: [process]" | Apply step 2 specifically |
+| "is this reasoning by analogy?" | Detect + replace analogy |
+
+## Files
+
+- `SKILL.md` — frontmatter, router, both frameworks, quick examples, anti-patterns
+- `references/first-principles.md` — full decomposition workflow + analogy detector
+- `references/algorithm.md` — 5-step algorithm with per-step checklists
+- `references/case-studies.md` — worked examples (battery, SpaceX, Tesla, software)
+
+## Requirements
+
+- None. Agent-agnostic. No tools.
+
+## License
+
+MIT

--- a/first-principles/SKILL.md
+++ b/first-principles/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: first-principles
+description: |
+  First-principles thinking + 5-step engineering algorithm (popularized by Elon Musk). Break problems down to fundamental physics/economics and rebuild solutions from scratch. Counters reasoning-by-analogy, inherited constraints, and premature optimization.
+  Auto-activates on: "first principles", "first-principles", "boil down to fundamentals", "decompose to atoms", "physics first", "reasoning by analogy", "challenge industry norm", "5-step algorithm", "musk algorithm", "make requirements less dumb", "delete the part", "what does the physics say".
+license: MIT
+compatibility: Agent-agnostic. No external tools required.
+metadata:
+  version: "1.0"
+allowed-tools: Read Glob Grep
+---
+
+# First Principles
+
+Two complementary frameworks for cutting through inherited constraints:
+
+1. **First-Principles Thinking** — *how to reason*: decompose to fundamentals, then reason up.
+2. **The 5-Step Algorithm** — *how to engineer*: requirements → delete → simplify → accelerate → automate, in order.
+
+Use Framework 1 when challenging assumptions and pricing/cost beliefs. Use Framework 2 when designing/optimizing a process or system. They compose: do (1) on the problem, then (2) on the solution.
+
+## When to Use
+
+| Situation | Framework | Why |
+|-----------|-----------|-----|
+| "We can't because [industry assumption]" | First Principles | Test if constraint is real or inherited |
+| "It costs $X because that's the market price" | First Principles | Cost from materials + physics, not market |
+| "Everyone does it like this" | First Principles | Reasoning-by-analogy detected |
+| Designing a new process/system | 5-Step Algorithm | Order prevents premature optimization |
+| Existing process is slow/expensive | 5-Step Algorithm | Most overhead is in step 1 (dumb requirements) |
+| Both: a hard problem with cost + design | 1 then 2 | Reframe problem (1), then build solution (2) |
+
+## Router
+
+| User says | Load reference | Do |
+|---|---|---|
+| "elon first principles" / "musk first principles" / "boil down to fundamentals" | `references/first-principles.md` | Run 4-step decomposition |
+| "what does the physics say" / "physics-first" / "decompose to atoms" | `references/first-principles.md` | Run physical-cost decomposition |
+| "musk algorithm" / "5-step algorithm" / "make requirements less dumb" | `references/algorithm.md` | Run 5 steps in order |
+| "delete the part" / "delete this step" | `references/algorithm.md` | Apply step 2 specifically |
+| "reasoning by analogy" / "challenge industry norm" | `references/first-principles.md` | Surface analogy → replace with first-principles |
+| Show worked examples | `references/case-studies.md` | Battery / SpaceX / Tesla manufacturing |
+
+---
+
+## Framework 1: First-Principles Thinking
+
+> "Boil things down to their fundamental truths and reason up from there, as opposed to reasoning by analogy." — Musk
+
+### The 4-Step Decomposition
+
+```
+┌──────────────────────────────────────────────────┐
+│ 1. STATE the assumption / inherited belief        │
+│    "X must cost / take / require Y"               │
+└────────────────┬─────────────────────────────────┘
+                 ▼
+┌──────────────────────────────────────────────────┐
+│ 2. DECOMPOSE to fundamentals                      │
+│    What atoms / physical quantities / unavoidable │
+│    economic inputs is this actually made of?      │
+└────────────────┬─────────────────────────────────┘
+                 ▼
+┌──────────────────────────────────────────────────┐
+│ 3. PRICE / COMPUTE the irreducible floor          │
+│    Sum the fundamentals at market / physical limit│
+└────────────────┬─────────────────────────────────┘
+                 ▼
+┌──────────────────────────────────────────────────┐
+│ 4. RECONSTRUCT — figure out how to combine them   │
+│    Gap between floor and current = opportunity    │
+└──────────────────────────────────────────────────┘
+```
+
+### Reasoning-by-Analogy Detector
+
+Stop and run Framework 1 when you hear:
+
+- "Industry standard is..."
+- "Everyone does it like this"
+- "It's always been..."
+- "Best practice says..."
+- "The market price is..."
+- "Vendors charge..."
+
+These are analogy-flags. Each one is a candidate for decomposition.
+
+### Output Template
+
+```markdown
+## First-Principles Brief: [Problem]
+
+### Stated Constraint
+[What everyone says is true / required / unavoidable]
+
+### Fundamentals (Atoms)
+| Component | Quantity | Unit Cost / Physical Limit | Source |
+|-----------|----------|----------------------------|--------|
+| ...       | ...      | ...                        | ...    |
+
+### Irreducible Floor
+**Total: [$X / Y kg / Z seconds]**
+
+### Current Reality
+**[$A / B kg / C seconds]** — gap of [ratio]× over the floor.
+
+### Where the Gap Comes From
+1. [Inherited assumption / margin / process step]
+2. ...
+
+### Reconstructed Path
+[Solution that approaches the floor — not the analog]
+```
+
+---
+
+## Framework 2: The 5-Step Algorithm
+
+> "Most of these mistakes I will catch — but I cannot bat 1000." — Musk, on why order matters
+
+Order is not optional. Run steps in sequence. Skipping ahead causes the most common failure mode: **optimizing or automating a dumb process**.
+
+### Steps (in order)
+
+```
+1. MAKE THE REQUIREMENTS LESS DUMB
+   Every requirement is wrong. Especially smart-people requirements.
+   Question who set it, when, and what they actually needed.
+
+2. DELETE THE PART OR PROCESS
+   If you're not adding back at least 10% of what you delete, you didn't delete enough.
+
+3. SIMPLIFY AND OPTIMIZE
+   Only AFTER deleting. Otherwise you're polishing a vestige.
+
+4. ACCELERATE CYCLE TIME
+   Speed up what survived. Not before — you'll just speed up wasted work.
+
+5. AUTOMATE
+   Last. Automating a broken process scales the breakage.
+```
+
+### Common Failure Mode
+
+```
+WRONG ORDER (most common):
+  AUTOMATE → SIMPLIFY → DELETE → REQUIREMENTS
+  → automating dumb requirements at high speed.
+
+RIGHT ORDER:
+  REQUIREMENTS → DELETE → SIMPLIFY → ACCELERATE → AUTOMATE
+```
+
+### Per-Step Checklist
+
+| Step | Question | Pass Criterion |
+|------|----------|----------------|
+| 1 | Is this requirement physically/economically necessary, or inherited? | Owner + reason traced; dumb ones removed |
+| 2 | Can this part/step be removed entirely? | <10% add-back rate after deletion |
+| 3 | Is what remains the simplest form? | No vestigial branches, configs, layers |
+| 4 | Where is cycle time spent? Can it be parallelized? | Critical path measured + reduced |
+| 5 | Is this stable enough to automate without locking in waste? | Steps 1-4 PASS first |
+
+### Output Template
+
+```markdown
+## 5-Step Pass: [System / Process]
+
+### 1. Requirements
+| Requirement | Owner | Origin | Verdict (keep/dumb/unknown) |
+|-------------|-------|--------|------------------------------|
+| ...         | ...   | ...    | ...                          |
+**Removed**: [list dumb requirements]
+
+### 2. Deletions
+| Part / Step | Why removed | Add-back? |
+|-------------|-------------|-----------|
+| ...         | ...         | yes/no    |
+**Add-back rate**: X% (target <10% — if higher, delete more aggressively next pass)
+
+### 3. Simplifications
+[What survived deletion, simplified]
+
+### 4. Cycle-Time Wins
+| Stage | Before | After | Method |
+|-------|--------|-------|--------|
+| ...   | ...    | ...   | parallelize / batch / cache |
+
+### 5. Automation
+[What was stable + worth automating, and what was deliberately left manual]
+```
+
+---
+
+## Composition: Framework 1 → Framework 2
+
+For hard problems with both cost beliefs AND a process to build:
+
+```
+Framework 1 (decompose problem)
+        │
+        ▼
+"The floor is $X. Current is $A. Gap = $A - $X."
+        │
+        ▼
+Framework 2 (build the path to the floor)
+        │
+        ▼
+Step 1: which requirements caused the gap?
+Step 2: which parts/steps in the current process are the gap?
+Step 3-5: simplify, accelerate, automate the survivors.
+```
+
+---
+
+## Quick Examples
+
+### Battery Cost (Framework 1)
+
+| Stated | "Batteries cost $600/kWh, will always be expensive" |
+| Atoms | Cobalt + nickel + aluminum + carbon + polymers + steel can |
+| Floor | ~$80/kWh at LME spot prices for the raw materials |
+| Gap | 7.5× — comes from cell design, manufacturing scale, vendor margins |
+| Reconstruct | Gigafactory: own the cell + scale + integrate |
+
+### Rocket Cost (Framework 1 → 2)
+
+| Stated | "Rockets cost $65M, single-use, that's just how it is" |
+| Atoms | Aluminum + copper + carbon fiber + propellant ≈ ~2% of price |
+| Floor | Materials + fuel ≈ low-single-digit millions |
+| Gap | Throwing the rocket away. Reasoning by analogy: "rockets are expendable" |
+| Reconstruct | Land + reuse → 5-Step Algorithm on landing process (delete legs? no — required by physics) |
+
+### Manufacturing Line (Framework 2)
+
+| 1. Requirements | "Body panels need 4 fasteners here" — origin: legacy CAD → reduce to 2 |
+| 2. Delete | Remove 30% of stations after audit; add-back rate 8% |
+| 3. Simplify | Merge two welding steps; eliminate one fixture |
+| 4. Accelerate | Parallelize paint cure with sub-assembly |
+| 5. Automate | Only the survived, simplified stations |
+
+---
+
+## Anti-Patterns (NEVER)
+
+- NEVER apply step 4 or 5 of the algorithm before steps 1-3 — you scale waste.
+- NEVER accept "industry standard" as a fundamental — it is an analogy by definition.
+- NEVER decompose to fundamentals and stop there — you must reconstruct (step 4 of Framework 1).
+- NEVER use first-principles to justify ignoring physical limits. The floor is real; the inherited markup is not.
+- NEVER skip step 1 of the algorithm because requirements "came from someone smart". Smart-people requirements are the hardest to question and the most expensive to keep.
+- NEVER delete a Chesterton's Fence requirement without tracing its origin. If origin = "physics" or "regulation", keep. If origin = "we always did it" — delete.
+
+---
+
+## Smoke Test
+
+User: *"This service costs us $50k/month. Vendors all charge in that range — what can we do?"*
+
+Expected activation: First Principles.
+
+Expected response: Decompose the $50k into compute + storage + bandwidth + vendor margin. Compute the cloud-floor at on-demand pricing. Identify gap. Then run 5-Step Algorithm on the integration to approach the floor.
+
+---
+
+## References
+
+- `references/first-principles.md` — full decomposition workflow + analogy detector
+- `references/algorithm.md` — 5-step algorithm with deeper checklists per step
+- `references/case-studies.md` — battery, SpaceX, Tesla manufacturing, software examples

--- a/first-principles/references/algorithm.md
+++ b/first-principles/references/algorithm.md
@@ -1,0 +1,203 @@
+# The 5-Step Algorithm (Reference)
+
+Musk's engineering algorithm, recorded during the Everyday Astronaut Starbase tour (2021). Five steps, in order. Reordering them is the single most common engineering failure.
+
+## The Steps
+
+```
+1. MAKE THE REQUIREMENTS LESS DUMB
+2. DELETE THE PART OR PROCESS
+3. SIMPLIFY AND OPTIMIZE
+4. ACCELERATE CYCLE TIME
+5. AUTOMATE
+```
+
+## Why Order Matters
+
+Each step exposes work that the next step would otherwise waste effort on:
+
+- Step 1 catches dumb requirements before they become parts (step 2 work).
+- Step 2 deletes parts before they get optimized (step 3 work).
+- Step 3 simplifies what survives before it gets sped up (step 4 work).
+- Step 4 reduces cycle time before it gets automated (step 5 work).
+
+**Anti-pattern**: starting at step 5. You will automate the broken process at high speed, and the breakage will scale.
+
+## Step 1 — Make the Requirements Less Dumb
+
+> "The requirements are definitely dumb. It does not matter who gave them to you. It is particularly dangerous if a smart person gave them to you, because you may not question them enough."
+
+### Process
+
+For every requirement on the system:
+
+| Field | Value |
+|-------|-------|
+| Requirement text | (verbatim) |
+| Owner (who set it) | name |
+| Origin date | when set |
+| Original problem it was solving | what was true then? |
+| Still true today? | yes / no / unknown |
+| Verdict | keep / dumb / unknown — investigate |
+
+### Pass Criterion
+
+Every requirement traces to (a) physics, (b) regulation with cited statute, (c) explicit customer/market need, OR is removed.
+
+### Watch For
+
+- "We've always required this" — often a fence to investigate (Chesterton).
+- "[Senior person] wanted it" — dangerous; smart-people requirements get over-respected.
+- "Just to be safe" — quantify the unsafe scenario or remove.
+- Specs lifted from a previous project — context-dependent; re-derive.
+
+## Step 2 — Delete the Part or Process
+
+> "If you are not occasionally adding things back in, you are not deleting enough."
+
+### Process
+
+For every part/step that survived Step 1:
+
+1. Try to delete it entirely.
+2. Build / run / test without it.
+3. Measure: did anything actually break?
+4. If no — keep deleted.
+5. If yes — add back the *minimum* needed.
+
+Track the **add-back rate**: number of deletions reverted / total deletions attempted.
+
+### Pass Criterion
+
+Add-back rate < 10%. Higher means you weren't aggressive enough.
+
+### Watch For
+
+- Parts whose only job is to fix other parts — delete the chain.
+- Configuration that exists "in case someone needs it" — delete.
+- Layers of abstraction with one consumer — delete the layer.
+- Tests for deleted code — delete.
+- Comments / docs about deleted code — delete.
+
+## Step 3 — Simplify and Optimize
+
+> "This step is third — not first — because the most common error of a smart engineer is to optimize a thing that should not exist."
+
+### Process
+
+For what survived Step 2:
+
+1. Reduce parameter count / surface area.
+2. Combine sequential operations that share state.
+3. Eliminate vestigial branches (if A then... when A is no longer reachable).
+4. Replace complex with simple where same outcome holds.
+
+### Pass Criterion
+
+Could a new engineer understand the system in one sitting?
+
+### Watch For
+
+- "Premature simplification" is also possible — don't merge things that *should* stay separate.
+- Optimization for benchmarks that don't reflect real load.
+
+## Step 4 — Accelerate Cycle Time
+
+> "Every process can be sped up. But only after the first three steps. Going faster on a process that should not exist is foolish."
+
+### Process
+
+1. Map the critical path.
+2. Identify wait states / serial dependencies.
+3. Parallelize what can be parallelized.
+4. Batch what's serial.
+5. Cache what's recomputed.
+
+### Pass Criterion
+
+Critical path latency reduced measurably. Document baseline → after.
+
+### Watch For
+
+- Adding parallelism that introduces races without speedup.
+- Caching adding stale-data bugs without measured win.
+- Speeding up a step that wasn't on the critical path (no overall improvement).
+
+## Step 5 — Automate
+
+> "Last. Most people do this first."
+
+### Process
+
+For each step that has been:
+
+- Stripped of dumb requirements (Step 1)
+- Stripped of unneeded parts (Step 2)
+- Simplified (Step 3)
+- Sped up (Step 4)
+
+…ask: is this stable enough that automating it locks in good behavior, not waste?
+
+If yes, automate.
+
+If unsure, leave manual until the process is stable.
+
+### Pass Criterion
+
+Automation reduces human-touch on stable, well-understood steps. Variability in upstream output is not absorbed by automation (that's automation as workaround — anti-pattern).
+
+### Watch For
+
+- Automating something that fails 5% of the time — you've automated the failure.
+- Automation that requires constant config tweaks — process isn't stable.
+- "We need automation to scale" without first asking *should we be doing this at all*.
+
+## Per-System Output Template
+
+```markdown
+## 5-Step Pass: [System / Process Name]
+
+**Baseline metrics**: [cycle time / cost / headcount / error rate]
+
+### Step 1: Requirements
+| Requirement | Owner | Origin | Still valid? | Verdict |
+|-------------|-------|--------|--------------|---------|
+| ... | ... | ... | ... | ... |
+**Removed**: [list]
+**Investigated**: [list of "unknown" requirements traced to source]
+
+### Step 2: Deletions
+| Part / step | Why removed | Add-back? | Reason for add-back |
+|-------------|-------------|-----------|---------------------|
+| ... | ... | yes/no | ... |
+**Add-back rate**: X% (target <10%)
+
+### Step 3: Simplifications
+| Before | After | Why simpler |
+|--------|-------|-------------|
+| ... | ... | ... |
+
+### Step 4: Cycle-Time Wins
+| Stage | Before | After | Method |
+|-------|--------|-------|--------|
+| ... | ... | ... | parallelize / batch / cache |
+**Critical path**: [before] → [after]
+
+### Step 5: Automation
+| Step | Automated? | Why / why not |
+|------|------------|---------------|
+| ... | yes/no | stable / unstable / human-judgment-required |
+
+### Final Metrics
+| Metric | Baseline | After |
+|--------|----------|-------|
+| Cycle time | ... | ... |
+| Cost | ... | ... |
+| Headcount | ... | ... |
+| Error rate | ... | ... |
+```
+
+## Cross-Reference
+
+- For *cost* / *constraint* beliefs (not process design), use `references/first-principles.md`.
+- For worked examples, see `references/case-studies.md`.

--- a/first-principles/references/case-studies.md
+++ b/first-principles/references/case-studies.md
@@ -1,0 +1,181 @@
+# Case Studies (Reference)
+
+Worked examples of both frameworks. Loaded when user asks for examples or wants to calibrate against real applications.
+
+## 1. Tesla Battery Cost (Framework 1)
+
+### Stated Constraint
+
+> "Battery packs cost $600/kWh. They will always be expensive. EVs cannot scale because of battery cost."
+
+(Industry consensus, ~2008.)
+
+### Atoms
+
+| Component | Source price | Required? |
+|-----------|--------------|-----------|
+| Cobalt | LME spot | yes |
+| Nickel | LME spot | yes |
+| Aluminum | LME spot | yes |
+| Carbon | commodity | yes |
+| Polymers | commodity | yes |
+| Steel can | commodity | yes |
+
+Sum at LME spot prices (Musk's quoted figure): **~$80/kWh**.
+
+### Floor
+
+**~$80/kWh** for raw materials. Manufacturing + cell design + scale on top.
+
+### Current Reality (then)
+
+**$600/kWh** — 7.5× the floor.
+
+### Gap Decomposition
+
+1. Sub-scale cell production (laptop-cell economics, not vehicle-scale).
+2. Vendor margin chains.
+3. Cell design optimized for consumer electronics, not automotive duty cycles.
+
+### Reconstruction
+
+Build cells at vehicle scale, integrate cell + pack + vehicle, remove vendor chain → Gigafactory.
+
+### Outcome
+
+Pack cost trended toward $100/kWh by ~2023. The "physics floor" was the right anchor.
+
+---
+
+## 2. SpaceX Reusability (Framework 1 → Framework 2)
+
+### Framework 1 — Stated Constraint
+
+> "Rockets are expendable. Launch costs are dominated by hardware. Nothing to be done."
+
+### Atoms
+
+| Component | Cost share |
+|-----------|------------|
+| Aluminum, copper, carbon fiber, propellant | ~2% of launch price |
+| Manufacturing labor + facilities | ~30-40% of hardware cost |
+| Hardware (one-shot use) | dominant |
+
+### Floor
+
+If hardware is reused N times: marginal cost approaches **fuel + refurb / N**, not full hardware.
+
+### Gap
+
+The entire price of the rocket, divided by 1 (uses) instead of N. Reasoning by analogy: "rockets are expendable, like all rockets before them."
+
+### Reconstruction
+
+Land + reuse the first stage → marginal cost trends toward fuel + refurbishment.
+
+### Framework 2 — On the Landing Process
+
+| Step | Application |
+|------|-------------|
+| 1. Requirements less dumb | Do we *need* legs, fins, throttleable engines? Trace each to physics. (Yes — physics-required.) |
+| 2. Delete | Eliminate barge if RTLS is feasible for the trajectory. Eliminate auxiliary systems. |
+| 3. Simplify | Single engine for landing burn (Merlin-1D throttle range). |
+| 4. Accelerate | Refurb cycle time: from months to days to "fly within 24 hours." |
+| 5. Automate | Autonomous landing — only after the trajectory was proven stable. |
+
+### Outcome
+
+Falcon 9 first-stage cost amortized over 10+ flights. Launch price dropped ~10×.
+
+---
+
+## 3. Tesla Manufacturing Line (Framework 2)
+
+### Context
+
+Model 3 production hell, 2018. Line was over-automated and stalling.
+
+### What Happened
+
+Musk's diagnosis publicly: he had skipped to step 5 (automate) before doing 1-3.
+
+| Step | What had gone wrong |
+|------|---------------------|
+| 1 | Requirements inherited from premium-segment Model S — many didn't apply to Model 3 |
+| 2 | Parts that could have been deleted were instead being assembled by robots |
+| 3 | No simplification pass before the line was built |
+| 4 | Cycle time targets were set against the un-simplified design |
+| 5 | Automation was scaling the dumb requirements (the failure mode) |
+
+### Recovery
+
+Run the algorithm in order. Public quote: "Excessive automation at Tesla was a mistake. To be precise, my mistake. Humans are underrated."
+
+### Lesson
+
+Step 5 last. Always.
+
+---
+
+## 4. Software Example: Microservice Migration (Framework 2)
+
+### Stated Goal
+
+"Migrate the monolith to microservices because that's how modern systems scale."
+
+### Framework 1 First (Catch the Analogy)
+
+| Phrase | Analog |
+|--------|--------|
+| "Modern systems scale this way" | Industry analog. What does the *physics of your traffic* require? |
+| "Microservices are best practice" | Best for what problem? Yours? |
+
+If actual traffic is 100 RPS and the team is 5 engineers, the floor doesn't require microservices. The analog does.
+
+### Framework 2 If You Decide to Restructure
+
+| Step | Application |
+|------|-------------|
+| 1. Requirements | Which services *must* be separate (compliance? blast-radius? team-ownership?). Delete the rest. |
+| 2. Delete | Half the services proposed in the migration plan. The ones with no independent owner. |
+| 3. Simplify | Merge services that share data. One DB, not seven. |
+| 4. Accelerate | Build pipelines, deploy times — only after the architecture is settled. |
+| 5. Automate | Service templates, scaffolding — only once the boundaries are stable. |
+
+### Lesson
+
+Most "microservices migrations" automate (step 5) a poorly-decomposed system (steps 1-3 skipped). They scale the wrong boundaries.
+
+---
+
+## 5. Personal: "Should I Hire?" (Framework 2)
+
+### Context
+
+"We need to hire someone to handle X."
+
+### Framework 2
+
+| Step | Question | Outcome |
+|------|----------|---------|
+| 1. Requirements | What does X actually require? Trace. | Often: 30% is unnecessary, inherited from previous role spec. |
+| 2. Delete | Can X be deleted entirely? | Sometimes: yes, the activity exists from inertia. |
+| 3. Simplify | What survives — is it the simplest form? | Often: scope shrinks 50%. |
+| 4. Accelerate | Existing team can do simplified X faster. | Sometimes: yes. |
+| 5. Automate | Can it be automated / scripted / outsourced? | Often: yes for the routine 80%. |
+
+If steps 1-5 leave no need, the hire is avoided. If they leave a real need, the role is *much smaller and more focused* than the original.
+
+---
+
+## How to Calibrate Your Own Cases
+
+For any new problem:
+
+1. State the inherited belief in one sentence.
+2. List the atoms.
+3. Compute the floor.
+4. If the gap is >2×, run the algorithm on the path from current to floor.
+5. If the gap is <2×, the analog is probably close to the floor — accept it and move on.
+
+The skill is not to apply both frameworks to everything. It is to **detect when a constraint is inherited** and **only then** spend the effort.

--- a/first-principles/references/first-principles.md
+++ b/first-principles/references/first-principles.md
@@ -1,0 +1,137 @@
+# First-Principles Decomposition (Reference)
+
+Loaded when user invokes first-principles thinking specifically (not the 5-step algorithm).
+
+## Core Definition
+
+**First principles** = a foundational proposition that cannot be deduced from any other (Aristotle).
+
+In Musk's usage: the **physical or economic atoms** of a problem — the things that *must* be true because of physics, materials, or unavoidable economic inputs.
+
+**Reasoning by analogy** = "X is like Y; do what Y does." Cheap, fast, and the source of most inherited cost.
+
+## The 4-Step Process
+
+### 1. STATE the Inherited Belief
+
+Write the assumption verbatim, with quote marks. Examples:
+
+- "Batteries will always cost $600/kWh."
+- "Rockets are expendable."
+- "Enterprise software has to take 18 months to deploy."
+- "Customer support requires N people per X tickets."
+
+If you cannot state it in one sentence with quote marks, you do not yet understand what you are challenging.
+
+### 2. DECOMPOSE to Atoms
+
+For each belief, list the **smallest physically/economically irreducible components**.
+
+| Belief Type | Atoms To List |
+|-------------|---------------|
+| Cost belief | Raw materials, labor-hours at market rate, energy, capital amortized over volume |
+| Time belief | Critical-path operations, physical limits (speed of light, chemical reaction time) |
+| Capability belief | Physical laws, material properties, information-theoretic limits |
+| Process belief | Inputs required by physics/regulation vs inputs required by current org |
+
+**Rule**: Every atom must be defensible against the question *"is this required by physics, or by convention?"*
+
+If the answer is "convention" — it is **not** an atom. It is a candidate for deletion.
+
+### 3. PRICE / COMPUTE the Floor
+
+Sum the atoms at their irreducible cost / time / size.
+
+Sources:
+
+- London Metal Exchange spot prices (materials)
+- Energy markets (kWh, fuel)
+- Physical constants (rocket equation, thermodynamics, information theory)
+- Cloud commodity pricing (compute, storage, bandwidth)
+
+The result is the **floor** — the lowest the thing can be without violating physics or markets.
+
+### 4. RECONSTRUCT
+
+The gap between the floor and the current reality is the opportunity.
+
+```
+Current Cost: $A
+Floor:        $X
+─────────────────
+Gap:          $A − $X  ← this is the entire opportunity
+```
+
+Where the gap comes from (in order of typical magnitude):
+
+1. **Inherited margin chains** — vendor → integrator → reseller, each adds 20-50%.
+2. **Volume / scale** — the floor assumes scale; current may be sub-scale.
+3. **Process design** — built around analog (the old way), not the floor.
+4. **Smart-people overhead** — each layer of abstraction added by experts.
+5. **Regulatory / safety floor** — sometimes real, often inherited.
+
+The reconstructed path picks one or more of these to attack — directly, not by analog.
+
+## Reasoning-by-Analogy Detector
+
+When you (or anyone) say one of these, **stop**:
+
+| Phrase | Analogy Hidden Inside |
+|--------|------------------------|
+| "Industry standard..." | The whole industry is the analogy |
+| "Best practice..." | Best for whose problem? |
+| "Vendors charge..." | Vendor pricing is a market analog, not a floor |
+| "It's always been..." | Tradition is an analog |
+| "Everyone does..." | The herd is an analog |
+| "The textbook says..." | Curated past, not your problem |
+| "In our industry..." | Industry boundaries are themselves analogs |
+
+For each, ask: **what physical or economic atom forces this?** If none, it is a candidate for replacement.
+
+## Output Template
+
+```markdown
+## First-Principles Brief: [Problem]
+
+### Stated Constraint
+"[verbatim quote of the inherited belief]"
+
+### Atoms (Fundamentals)
+| Component | Quantity | Unit Cost / Limit | Source | Required by physics? |
+|-----------|----------|-------------------|--------|----------------------|
+| ...       | ...      | ...               | ...    | yes/no                |
+
+### Irreducible Floor
+**[$X / Y units]**
+
+### Current Reality
+**[$A / B units]** — [ratio]× the floor.
+
+### Gap Decomposition
+1. [Inherited margin / scale / process / overhead] — ~$Z
+2. ...
+
+### Analogies Identified
+- [Analogy 1]: [what's the underlying atom?] [is it real?]
+- ...
+
+### Reconstructed Path
+[Step-by-step approach that targets the gap, not the analog]
+
+### What Would Falsify This
+[The specific evidence that would invalidate the floor or the gap analysis]
+```
+
+## Common Mistakes
+
+| Mistake | Why it fails | Fix |
+|---------|--------------|-----|
+| Decomposing without re-pricing at floor | You restate the problem in atoms but inherit market price | Use commodity / spot prices, not vendor quotes |
+| Stopping at decomposition | You found the floor but didn't reconstruct | Step 4 is mandatory; without it, this is just analysis |
+| Treating "regulation" as physics | Some regulations are inherited; some are physical safety | Trace each regulation to its origin |
+| Calling smart-people overhead "irreducible" | Smart additions feel necessary; usually aren't | Apply step 1 of the 5-step algorithm to them |
+
+## Cross-Reference
+
+- After running this on a problem, run `references/algorithm.md` on the *solution* you reconstruct.
+- See `references/case-studies.md` for battery, SpaceX, Tesla worked examples.

--- a/llms.txt
+++ b/llms.txt
@@ -23,6 +23,7 @@ Install: `npx skills add bntvllnt/agent-skills`
 - [Convex](convex/SKILL.md): Convex backend — functions, schemas, auth, scheduling, workflows
 - [Workflow](workflow/SKILL.md): High-velocity solo development — plan, ship, fix, review, done
 - [tmux](tmux/SKILL.md): Terminal multiplexer — sessions, windows, panes, layouts, scripting
+- [First Principles](first-principles/SKILL.md): First-principles thinking + 5-step engineering algorithm (popularized by Musk)
 
 ## Optional
 


### PR DESCRIPTION
## Summary

Adds new `first-principles` skill encoding two composable mental frameworks (popularized by Elon Musk):

- **First-Principles Thinking** — 4-step decomposition: state assumption → break to physical/economic atoms → compute irreducible floor → reconstruct path. Counters reasoning-by-analogy.
- **5-Step Engineering Algorithm** — *make requirements less dumb → delete the part → simplify → accelerate → automate*, in order. Counters premature optimization.

Skill count: 8 → 9.

## Files

- `first-principles/SKILL.md` — frontmatter, router, both frameworks, composition pattern, anti-patterns
- `first-principles/README.md` — overview + entry points
- `first-principles/references/first-principles.md` — full decomposition workflow + reasoning-by-analogy detector
- `first-principles/references/algorithm.md` — 5-step algorithm with per-step checklists
- `first-principles/references/case-studies.md` — battery cost, SpaceX reusability, Tesla manufacturing, microservices migration, hiring

## Index updates

- `README.md` — listing + install commands + badge (8 → 9)
- `llms.txt` — skills section
- `docs/skills-overview.md` — table

## Trigger collision resolved

Dropped `"first principles"` from `analyze/SKILL.md` triggers (analyze keeps `"challenge assumptions"` and its multi-perspective first-principles-analysis sub-section). New skill owns the trigger.

## Test plan

- [ ] Verify SKILL.md frontmatter is valid YAML
- [ ] Activate via `"first principles on [problem]"` — should load this skill, not analyze
- [ ] Activate via `"5-step algorithm on [process]"` — should run framework 2
- [ ] Skim references/ for accuracy on case studies